### PR TITLE
Issue #24: per-client torrents endpoint and active-tab polling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -190,7 +190,7 @@ Flask blueprints in `web/routes/`:
   - `system.py` - `/health`, `/config` endpoints
   - `download_clients.py` - Download client CRUD operations
   - `connections.py` - Transfer connection CRUD operations
-  - `torrents.py` - `/torrents`, `/all_torrents` endpoints
+  - `torrents.py` - `/torrents`, `/clients/<client_name>/torrents` endpoints
   - `transfers.py` - `/transfers` history endpoints (list, stats, delete)
   - `manual_transfers.py` - `/transfers/destinations`, `/transfers/manual` manual transfer endpoints
   - `auth.py` - `/auth/*` authentication settings and API key management endpoints

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -254,7 +254,7 @@ Manual Transfer API endpoint tests (20 tests).
 |------------|-------|-------------|
 | `TestDestinationsEndpoint` | 4 | GET /transfers/destinations — known source, missing param, unknown source, target with no connections |
 | `TestManualTransferValidation` | 7 | POST /transfers/manual validation — empty hashes, missing fields, unknown clients, same src/dest, nonexistent hash |
-| `TestManualTransferInitiation` | 4 | POST /transfers/manual happy path — single transfer lifecycle, multiple torrents, not-seeding rejection, all_torrents field verification |
+| `TestManualTransferInitiation` | 5 | POST /transfers/manual happy path — single transfer lifecycle, multiple torrents, not-seeding rejection, per-client torrent field verification, unknown-client torrents endpoint |
 | `TestManualTransferCrossSeed` | 2 | Cross-seed expansion — selecting one torrent transfers sibling with same save_path; disabled flag prevents expansion |
 | `TestDestinationsWithTorrentConfig` | 1 | Destinations with torrent transfer config — transfer_type=torrent |
 | `TestManualTorrentTypeTransfer` | 1 | POST /transfers/manual — manual torrent (P2P) transfer completes end-to-end |

--- a/tests/integration/api/test_manual_transfer_api.py
+++ b/tests/integration/api/test_manual_transfer_api.py
@@ -8,6 +8,7 @@ import base64
 import os
 import time
 import uuid
+from urllib.parse import quote
 
 import pytest
 import requests
@@ -30,6 +31,11 @@ def get_api_url():
     host = SERVICES['transferarr']['host']
     port = SERVICES['transferarr']['port']
     return f"http://{host}:{port}/api/v1"
+
+
+def get_client_torrents_url(client_name: str) -> str:
+    """Get the per-client torrents endpoint URL."""
+    return f"{get_api_url()}/clients/{quote(client_name, safe='')}/torrents"
 
 
 MOCK_INDEXER_HOST = os.environ.get("MOCK_INDEXER_HOST", "mock-indexer")
@@ -361,13 +367,14 @@ class TestManualTransferInitiation:
         # 2. Start transferarr
         transferarr.start(wait_healthy=True)
 
-        # 3. Verify torrent appears in all_torrents
-        all_url = f"{get_api_url()}/all_torrents"
-        resp = requests.get(all_url, timeout=TIMEOUTS['api_response'])
+        # 3. Verify torrent appears in the source client's torrent listing
+        resp = requests.get(
+            get_client_torrents_url("source-deluge"),
+            timeout=TIMEOUTS['api_response'],
+        )
         assert resp.status_code == 200
-        all_data = resp.json()["data"]
-        assert "source-deluge" in all_data
-        assert torrent["hash"] in all_data["source-deluge"]
+        source_data = resp.json()["data"]
+        assert torrent["hash"] in source_data
 
         # 4. Initiate manual transfer
         url = f"{get_api_url()}/transfers/manual"
@@ -501,27 +508,42 @@ class TestManualTransferInitiation:
         assert "seeding" in resp.json().get("error", {}).get("message", "").lower()
 
     @pytest.mark.timeout(TIMEOUTS['torrent_transfer'])
-    def test_all_torrents_includes_save_path(
+    def test_client_torrents_includes_save_path(
         self, transferarr, deluge_source, create_torrent,
     ):
-        """Verify /all_torrents response includes save_path and total_size."""
+        """Verify per-client torrent response includes save_path and total_size."""
         unique_name = f"manual_fields_{uuid.uuid4().hex[:6]}"
         torrent = add_torrent_to_deluge(deluge_source, unique_name, create_torrent)
 
         transferarr.start(wait_healthy=True)
 
-        all_url = f"{get_api_url()}/all_torrents"
-        resp = requests.get(all_url, timeout=TIMEOUTS['api_response'])
+        resp = requests.get(
+            get_client_torrents_url("source-deluge"),
+            timeout=TIMEOUTS['api_response'],
+        )
         assert resp.status_code == 200
 
-        client_data = resp.json()["data"].get("source-deluge", {})
-        torrent_data = client_data.get(torrent["hash"])
+        torrent_data = resp.json()["data"].get(torrent["hash"])
         assert torrent_data is not None, f"Torrent {torrent['hash']} not in response"
 
         assert "save_path" in torrent_data, f"Missing save_path. Keys: {torrent_data.keys()}"
         assert "total_size" in torrent_data, f"Missing total_size. Keys: {torrent_data.keys()}"
         assert isinstance(torrent_data["save_path"], str)
         assert torrent_data["total_size"] > 0
+
+    @pytest.mark.timeout(TIMEOUTS['api_response'])
+    def test_client_torrents_unknown_client_returns_404(self, transferarr):
+        """Unknown client returns 404 from the per-client torrents endpoint."""
+        transferarr.start(wait_healthy=True)
+
+        resp = requests.get(
+            get_client_torrents_url("missing-client"),
+            timeout=TIMEOUTS['api_response'],
+        )
+
+        assert resp.status_code == 404
+        error = resp.json()["error"]
+        assert error["code"] == "CLIENT_NOT_FOUND"
 
 
 # ==============================================================================
@@ -637,11 +659,13 @@ class TestManualTorrentTypeTransfer:
         # Start with torrent-transfer config (uses tracker, no SFTP)
         transferarr.start(config_type='torrent-transfer', wait_healthy=True)
 
-        # Verify torrent appears in all_torrents
-        all_url = f"{get_api_url()}/all_torrents"
-        resp = requests.get(all_url, timeout=TIMEOUTS['api_response'])
+        # Verify torrent appears in the source client's listing
+        resp = requests.get(
+            get_client_torrents_url("source-deluge"),
+            timeout=TIMEOUTS['api_response'],
+        )
         assert resp.status_code == 200
-        assert torrent["hash"] in resp.json()["data"].get("source-deluge", {})
+        assert torrent["hash"] in resp.json()["data"]
 
         # Initiate manual transfer
         url = f"{get_api_url()}/transfers/manual"
@@ -716,10 +740,12 @@ class TestManualTransferCrossSeed:
         # 2. Verify both have the same save_path and name in the API
         transferarr.start(wait_healthy=True)
 
-        all_url = f"{get_api_url()}/all_torrents"
-        resp = requests.get(all_url, timeout=TIMEOUTS['api_response'])
+        resp = requests.get(
+            get_client_torrents_url("source-deluge"),
+            timeout=TIMEOUTS['api_response'],
+        )
         assert resp.status_code == 200
-        source_data = resp.json()["data"].get("source-deluge", {})
+        source_data = resp.json()["data"]
         assert torrent_a["hash"] in source_data, "Original not in listing"
         assert torrent_b["hash"] in source_data, "Cross-seed not in listing"
 
@@ -792,10 +818,12 @@ class TestManualTransferCrossSeed:
         # 3. Verify they have DIFFERENT save_paths but same name+size
         transferarr.start(wait_healthy=True)
 
-        all_url = f"{get_api_url()}/all_torrents"
-        resp = requests.get(all_url, timeout=TIMEOUTS['api_response'])
+        resp = requests.get(
+            get_client_torrents_url("source-deluge"),
+            timeout=TIMEOUTS['api_response'],
+        )
         assert resp.status_code == 200
-        source_data = resp.json()["data"].get("source-deluge", {})
+        source_data = resp.json()["data"]
         assert torrent_a["hash"] in source_data, "Original not in listing"
         assert torrent_b["hash"] in source_data, "Cross-seed not in listing"
 

--- a/tests/ui/e2e/test_e2e_workflows.py
+++ b/tests/ui/e2e/test_e2e_workflows.py
@@ -9,6 +9,7 @@ to verify critical user journeys work correctly.
 """
 import re
 import time
+from urllib.parse import quote
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -189,27 +190,27 @@ class TestE2ETorrentWorkflow:
         log_test_step("Step 4: Verify source client shows torrent")
         # Find and click the source-deluge tab
         source_tab_found = False
+        source_tab_name = None
+        client_torrents_response = None
         for tab_name in tab_names:
             if 'source' in tab_name.lower():
-                torrents_page.switch_to_client_tab(tab_name)
+                encoded_source = quote(tab_name, safe='')
+                with page.expect_response(
+                    lambda r, encoded_source=encoded_source: f"/api/v1/clients/{encoded_source}/torrents" in r.url,
+                    timeout=UI_TIMEOUTS['api_response']
+                ) as response_info:
+                    torrents_page.switch_to_client_tab(tab_name)
+                client_torrents_response = response_info.value.json()
+                source_tab_name = tab_name
                 source_tab_found = True
                 break
         
         if source_tab_found:
             # Wait for tab content to load
             page.wait_for_timeout(UI_TIMEOUTS['dropdown_load'])
-            
-            # Check for torrent in the list (via API response)
-            with page.expect_response(
-                lambda r: "/api/v1/all_torrents" in r.url,
-                timeout=UI_TIMEOUTS['api_response']
-            ) as response_info:
-                page.reload()
-            
-            all_torrents_response = response_info.value.json()
-            # Unwrap data envelope (supports both old and new format)
-            all_torrents = all_torrents_response.get('data', all_torrents_response) if isinstance(all_torrents_response, dict) and 'data' in all_torrents_response else all_torrents_response
-            print(f"  All torrents response: {list(all_torrents.keys())}")
+            client_torrents_response = response_info.value.json()
+            client_torrents = client_torrents_response.get('data', client_torrents_response) if isinstance(client_torrents_response, dict) and 'data' in client_torrents_response else client_torrents_response
+            print(f"  Source client {source_tab_name} has {len(client_torrents)} torrents visible")
         
         log_test_step("Step 5: Wait for transfer to complete")
         # Wait for torrent to reach target
@@ -474,27 +475,30 @@ class TestE2ECrossPageWorkflows:
         assert len(tabs) >= 1, "Should have at least one client tab"
         print(f"  Torrents page has {len(tabs)} client tabs")
         
-        # Check via API that torrent is in the response
-        with page.expect_response(
-            lambda r: "/api/v1/all_torrents" in r.url,
-            timeout=UI_TIMEOUTS['api_response']
-        ) as response_info:
-            page.reload()
-        
-        all_torrents_response = response_info.value.json()
-        # Unwrap data envelope (supports both old and new format)
-        all_torrents = all_torrents_response.get('data', all_torrents_response) if isinstance(all_torrents_response, dict) and 'data' in all_torrents_response else all_torrents_response
-        # all_torrents is dict of client_name -> dict of torrent_hash -> torrent_info
+        # Check via API that torrent is in the target client's response
+        target_tab_name = None
+        target_torrents_response = None
+        for tab in tabs:
+            tab_name = tab.text_content().strip()
+            if 'target' in tab_name.lower():
+                encoded_target = quote(tab_name, safe='')
+                with page.expect_response(
+                    lambda r, encoded_target=encoded_target: f"/api/v1/clients/{encoded_target}/torrents" in r.url,
+                    timeout=UI_TIMEOUTS['api_response']
+                ) as response_info:
+                    torrents_page.switch_to_client_tab(tab_name)
+                target_torrents_response = response_info.value.json()
+                target_tab_name = tab_name
+                break
+
+        assert target_tab_name is not None, "Could not find target client tab"
+        target_torrents = target_torrents_response.get('data', target_torrents_response) if isinstance(target_torrents_response, dict) and 'data' in target_torrents_response else target_torrents_response
         found = False
-        for client_name, client_torrents in all_torrents.items():
-            # client_torrents is a dict keyed by torrent hash
-            for torrent_hash, torrent_info in client_torrents.items():
-                name = torrent_info.get('name', '') if isinstance(torrent_info, dict) else ''
-                if name == torrent_name or torrent_name in name:
-                    found = True
-                    print(f"  Found torrent on client: {client_name}")
-                    break
-            if found:
+        for torrent_hash, torrent_info in target_torrents.items():
+            name = torrent_info.get('name', '') if isinstance(torrent_info, dict) else ''
+            if name == torrent_name or torrent_name in name:
+                found = True
+                print(f"  Found torrent on client: {target_tab_name}")
                 break
         
         assert found, f"Torrent {torrent_name} not found in any client"

--- a/tests/ui/e2e/test_manual_transfer_e2e.py
+++ b/tests/ui/e2e/test_manual_transfer_e2e.py
@@ -12,6 +12,7 @@ Prerequisites:
 import base64
 import time
 import uuid
+from urllib.parse import quote
 
 import pytest
 import requests
@@ -24,6 +25,37 @@ from tests.ui.helpers import UI_TIMEOUTS, log_test_step
 
 # Mock indexer URL for downloading .torrent files
 MOCK_INDEXER_URL = f"http://{SERVICES.get('mock_indexer', {}).get('host', 'localhost')}:{SERVICES.get('mock_indexer', {}).get('port', 9696)}"
+
+
+def _get_client_torrents(client_name: str, timeout: int = 10) -> dict:
+    """Fetch torrents for a single client from transferarr."""
+    response = requests.get(
+        f"http://{SERVICES['transferarr']['host']}:{SERVICES['transferarr']['port']}/api/v1/clients/{quote(client_name, safe='')}/torrents",
+        timeout=timeout,
+    )
+    assert response.status_code == 200, f"Unexpected status {response.status_code}: {response.text}"
+    return response.json().get("data", {})
+
+
+def _wait_for_client_hash(client_name: str, torrent_hash: str, timeout: int = 30) -> None:
+    """Wait until a torrent hash appears in a client's API listing.
+
+    The per-client endpoint can briefly reset connections or return a non-200
+    during startup even after the health endpoint is live, so polling here
+    treats those transient failures as retryable.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if torrent_hash in _get_client_torrents(client_name):
+                return
+        except (AssertionError, requests.RequestException):
+            pass
+        time.sleep(2)
+
+    pytest.fail(
+        f"Torrent {torrent_hash} did not appear in the {client_name} client listing within {timeout} s"
+    )
 
 
 def _add_torrent_to_deluge(deluge_client, name, create_torrent_fn, size_mb=1):
@@ -101,20 +133,7 @@ class TestManualTransferE2E:
         log_test_step("Step 2: Start transferarr")
         self.transferarr.start(wait_healthy=True)
 
-        # Wait until /all_torrents includes the hash
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            resp = requests.get(
-                f"http://{SERVICES['transferarr']['host']}:{SERVICES['transferarr']['port']}/api/v1/all_torrents",
-                timeout=10,
-            )
-            if resp.status_code == 200:
-                data = resp.json().get("data", {})
-                if torrent["hash"] in data.get("source-deluge", {}):
-                    break
-            time.sleep(2)
-        else:
-            pytest.fail("Torrent did not appear in /all_torrents within 30 s")
+        _wait_for_client_hash("source-deluge", torrent["hash"])
 
         # -----------------------------------------------------------
         # 3. Navigate to the Torrents page and select the torrent
@@ -218,22 +237,11 @@ class TestManualTransferE2E:
     ):
         """After confirming, a success toast notification appears."""
         unique_name = f"ui_manual_toast_{uuid.uuid4().hex[:6]}"
-        _add_torrent_to_deluge(deluge_source, unique_name, create_torrent, size_mb=1)
+        torrent = _add_torrent_to_deluge(deluge_source, unique_name, create_torrent, size_mb=1)
 
         self.transferarr.start(wait_healthy=True)
 
-        # Wait for torrent in API
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            resp = requests.get(
-                f"http://{SERVICES['transferarr']['host']}:{SERVICES['transferarr']['port']}/api/v1/all_torrents",
-                timeout=10,
-            )
-            if resp.status_code == 200:
-                data = resp.json().get("data", {})
-                if unique_name in str(data.get("source-deluge", {})):
-                    break
-            time.sleep(2)
+        _wait_for_client_hash("source-deluge", torrent["hash"])
 
         torrents_page.goto()
         torrents_page.wait_for_torrents_loaded()

--- a/tests/ui/e2e/test_smoke.py
+++ b/tests/ui/e2e/test_smoke.py
@@ -10,6 +10,8 @@ This test simulates a new user setting up Transferarr from scratch:
 
 This is a comprehensive test that validates the entire user workflow.
 """
+from urllib.parse import quote
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -328,36 +330,34 @@ class TestE2EFullSmokeTest:
         
         # Find and switch to target tab
         target_tab_found = False
+        target_tab_name = None
+        target_torrents_response = None
         for tab_name in tab_names:
             if 'target' in tab_name.lower():
-                torrents_page.switch_to_client_tab(tab_name)
+                encoded_target = quote(tab_name, safe='')
+                with page.expect_response(
+                    lambda r, encoded_target=encoded_target: f"/api/v1/clients/{encoded_target}/torrents" in r.url,
+                    timeout=UI_TIMEOUTS['api_response']
+                ) as response_info:
+                    torrents_page.switch_to_client_tab(tab_name)
+                target_torrents_response = response_info.value.json()
+                target_tab_name = tab_name
                 target_tab_found = True
                 break
         
         assert target_tab_found, f"Could not find target client tab in {tab_names}"
-        
-        # Verify via API that torrent is on target
-        with page.expect_response(
-            lambda r: "/api/v1/all_torrents" in r.url,
-            timeout=UI_TIMEOUTS['api_response']
-        ) as response_info:
-            page.reload()
-        
-        all_torrents_response = response_info.value.json()
-        # Unwrap data envelope (supports both old and new format)
-        all_torrents = all_torrents_response.get('data', all_torrents_response) if isinstance(all_torrents_response, dict) and 'data' in all_torrents_response else all_torrents_response
-        
-        # Find torrent on target client
+
+        # Verify via API that torrent is on the active target client
+        target_torrents = target_torrents_response.get('data', target_torrents_response) if isinstance(target_torrents_response, dict) and 'data' in target_torrents_response else target_torrents_response
+
         found_on_target = False
-        for client_name, client_torrents in all_torrents.items():
-            if 'target' in client_name.lower():
-                for torrent_hash, torrent_data in client_torrents.items():
-                    name = torrent_data.get('name', '') if isinstance(torrent_data, dict) else ''
-                    if torrent_name in name:
-                        found_on_target = True
-                        print(f"  ✓ Found torrent on target client: {client_name}")
-                        break
-        
+        for torrent_hash, torrent_data in target_torrents.items():
+            name = torrent_data.get('name', '') if isinstance(torrent_data, dict) else ''
+            if torrent_name in name:
+                found_on_target = True
+                print(f"  ✓ Found torrent on target client: {target_tab_name}")
+                break
+
         assert found_on_target, f"Torrent {torrent_name} not found on target client!"
         
         print("\n" + "="*60)

--- a/tests/ui/fast/test_manual_transfer.py
+++ b/tests/ui/fast/test_manual_transfer.py
@@ -14,6 +14,7 @@ No actual transfers are initiated — these tests verify UI elements only.
 import base64
 import time
 import uuid
+from urllib.parse import quote
 
 import pytest
 import requests
@@ -25,6 +26,30 @@ from tests.utils import clear_deluge_torrents, clear_mock_indexer_torrents, deco
 
 
 MOCK_INDEXER_URL = f"http://{SERVICES['mock_indexer']['host']}:{SERVICES['mock_indexer']['port']}"
+
+
+def _get_client_torrents(client_name, timeout=5):
+    """Fetch torrents for a single client from the API."""
+    response = requests.get(
+        f"{TRANSFERARR_BASE_URL}/api/v1/clients/{quote(client_name, safe='')}/torrents",
+        timeout=timeout,
+    )
+    assert response.status_code == 200, f"Unexpected status {response.status_code}: {response.text}"
+    return response.json().get("data", {})
+
+
+def _wait_for_client_hashes(client_name, hashes, failure_message, timeout=30):
+    """Wait until the requested hashes appear for a specific client."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            client_torrents = _get_client_torrents(client_name)
+            if set(hashes).issubset(set(client_torrents.keys())):
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+    pytest.fail(failure_message)
 
 
 def _add_seeding_torrent(deluge_client, name, create_torrent_fn, size_mb=1):
@@ -206,20 +231,11 @@ def seeding_torrents(docker_client, docker_services, deluge_source, deluge_targe
     mgr.start()
     mgr.set_auth_disabled()
 
-    # Wait until both hashes appear in /all_torrents
-    deadline = time.time() + 30
-    while time.time() < deadline:
-        try:
-            r = requests.get(f"{TRANSFERARR_BASE_URL}/api/v1/all_torrents", timeout=5)
-            if r.status_code == 200:
-                src = r.json().get("data", {}).get("source-deluge", {})
-                if t1["hash"] in src and t2["hash"] in src:
-                    break
-        except requests.RequestException:
-            pass
-        time.sleep(2)
-    else:
-        pytest.fail("Seeding torrents did not appear in /all_torrents")
+    _wait_for_client_hashes(
+        "source-deluge",
+        {t1["hash"], t2["hash"]},
+        "Seeding torrents did not appear in the source client listing",
+    )
 
     yield [t1, t2]
 
@@ -862,31 +878,39 @@ def cross_seed_torrents(docker_client, docker_services, deluge_source, deluge_ta
     mgr.start()
     mgr.set_auth_disabled()
 
-    # Wait until all hashes appear in /all_torrents
+    # Wait until all hashes appear in the source client's listing
     all_hashes = {
         same_a["hash"], same_b["hash"],
         diff_a["hash"], diff_b["hash"],
         standalone["hash"],
     }
-    deadline = time.time() + 30
-    while time.time() < deadline:
-        try:
-            r = requests.get(f"{TRANSFERARR_BASE_URL}/api/v1/all_torrents", timeout=5)
-            if r.status_code == 200:
-                src = r.json().get("data", {}).get("source-deluge", {})
-                if all_hashes.issubset(set(src.keys())):
-                    break
-        except requests.RequestException:
-            pass
-        time.sleep(2)
-    else:
-        pytest.fail("Cross-seed torrents did not appear in /all_torrents")
+    _wait_for_client_hashes(
+        "source-deluge",
+        all_hashes,
+        "Cross-seed torrents did not appear in the source client listing",
+    )
+
+    source_torrents = _get_client_torrents("source-deluge")
+
+    def _split_original_and_non_original(first, second):
+        first_time = source_torrents.get(first["hash"], {}).get("time_added", float("inf"))
+        second_time = source_torrents.get(second["hash"], {}).get("time_added", float("inf"))
+        if first_time <= second_time:
+            return first, second
+        return second, first
+
+    same_original, same_non_original = _split_original_and_non_original(same_a, same_b)
+    diff_original, diff_non_original = _split_original_and_non_original(diff_a, diff_b)
 
     yield {
         "same_path_a": same_a,
         "same_path_b": same_b,
+        "same_path_original": same_original,
+        "same_path_non_original": same_non_original,
         "diff_path_a": diff_a,
         "diff_path_b": diff_b,
+        "diff_path_original": diff_original,
+        "diff_path_non_original": diff_non_original,
         "standalone": standalone,
     }
 
@@ -1288,9 +1312,8 @@ class TestOriginalTorrentIndicator:
 
     def test_original_at_top_when_non_original_selected(self, torrents_page):
         """When a non-original cross-seed is selected, the original still appears at the top."""
-        # Select same_path_b (the non-original cross-seed)
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_b"]["hash"],
+            torrents_page, self.data["same_path_non_original"]["hash"],
         )
 
         # Should still have exactly 1 Original badge
@@ -1311,9 +1334,8 @@ class TestOriginalTorrentIndicator:
         communicates the intent for all top-section items, so individual action
         badges are unnecessary.
         """
-        # Select same_path_b (not the original)
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_b"]["hash"],
+            torrents_page, self.data["same_path_non_original"]["hash"],
         )
 
         # Top-section items should have no action badges — subtitle covers it
@@ -1347,7 +1369,7 @@ class TestSelectedBadge:
     def test_selected_badge_on_original_when_original_selected(self, torrents_page):
         """Selecting the original shows both Original and Selected badges on the top item."""
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_a"]["hash"],
+            torrents_page, self.data["same_path_original"]["hash"],
         )
 
         selected_badges = torrents_page.get_selected_badges()
@@ -1363,7 +1385,7 @@ class TestSelectedBadge:
     def test_selected_badge_on_non_original_in_cross_seed_section(self, torrents_page):
         """Selecting a non-original shows Selected badge on the sibling in the cross-seed section."""
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_b"]["hash"],
+            torrents_page, self.data["same_path_non_original"]["hash"],
         )
 
         selected_badges = torrents_page.get_selected_badges()
@@ -1411,7 +1433,7 @@ class TestSelectedBadge:
     def test_non_original_selected_has_action_badge(self, torrents_page):
         """The selected non-original in the cross-seed section also gets action badges."""
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_b"]["hash"],
+            torrents_page, self.data["same_path_non_original"]["hash"],
         )
 
         # Second item is the selected non-original — should have Delete badge
@@ -1509,7 +1531,7 @@ class TestActionBadges:
     def test_no_action_dims_sibling(self, torrents_page):
         """When no action is set, the cross-seed item has the inactive class."""
         self._select_and_open_modal(
-            torrents_page, self.data["same_path_a"]["hash"],
+            torrents_page, self.data["same_path_original"]["hash"],
         )
 
         # Uncheck Delete

--- a/tests/ui/fast/test_torrents.py
+++ b/tests/ui/fast/test_torrents.py
@@ -8,6 +8,8 @@ Tests the torrents page functionality including:
 - Automatic polling behavior
 """
 import re
+from urllib.parse import quote
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -184,14 +186,16 @@ class TestTorrentsPolling:
     def test_torrents_page_polls_api(self, torrents_page, page: Page):
         """Test that torrents page polls the API for updates.
         
-        Torrents.js polls /api/v1/all_torrents every 3 seconds.
+        Torrents.js polls /api/v1/clients/<client>/torrents every 10 seconds.
         """
         torrents_page.goto()
         torrents_page.wait_for_torrents_loaded()
+        active_client = torrents_page.get_active_client_tab()
+        encoded_name = quote(active_client, safe='')
         
-        # Wait for API call (should happen within 5 seconds)
+        # Wait for the next scheduled poll (10-second interval)
         with page.expect_response(
-            lambda r: "/api/v1/all_torrents" in r.url,
+            lambda r: f"/api/v1/clients/{encoded_name}/torrents" in r.url,
             timeout=UI_TIMEOUTS['api_response']
         ) as response_info:
             pass  # Wait for next poll cycle
@@ -205,6 +209,70 @@ class TestTorrentsPolling:
         
         # Should not raise timeout
         torrents_page.wait_for_api_refresh(timeout=UI_TIMEOUTS['api_response'])
+
+    def test_slow_poll_response_does_not_trigger_overlapping_fetch(self, torrents_page, page: Page):
+        """A slow poll response should finish before the next poll begins."""
+        page.add_init_script(
+            """
+            (() => {
+                const originalFetch = window.fetch.bind(window);
+                window.__torrentClientFetchCount = 0;
+
+                window.fetch = (input, init) => {
+                    const url = typeof input === 'string' ? input : input.url;
+                    if (/\/api\/v1\/clients\/[^/]+\/torrents$/.test(url)) {
+                        window.__torrentClientFetchCount += 1;
+
+                        if (window.__torrentClientFetchCount === 2) {
+                            return new Promise((resolve, reject) => {
+                                window.setTimeout(() => {
+                                    originalFetch(input, init).then(resolve, reject);
+                                }, 12000);
+                            });
+                        }
+                    }
+
+                    return originalFetch(input, init);
+                };
+            })();
+            """
+        )
+
+        torrents_page.goto()
+        torrents_page.wait_for_torrents_loaded()
+
+        page.wait_for_function(
+            "() => window.__torrentClientFetchCount >= 2",
+            timeout=25000,
+        )
+
+        page.wait_for_timeout(11000)
+        fetch_count = page.evaluate("window.__torrentClientFetchCount")
+
+        assert fetch_count == 2, (
+            "Expected the next poll to wait for the slow in-flight response to finish; "
+            f"saw {fetch_count} client fetches instead"
+        )
+
+    def test_tab_switch_triggers_immediate_client_fetch(self, torrents_page, page: Page):
+        """Switching tabs immediately fetches the newly active client's torrents."""
+        torrents_page.goto()
+        torrents_page.wait_for_torrents_loaded()
+
+        tabs = torrents_page.get_client_tabs()
+        if len(tabs) < 2:
+            pytest.skip("Need at least two configured clients")
+
+        second_name = tabs[1].text_content().strip()
+        encoded_name = quote(second_name, safe='')
+
+        with page.expect_response(
+            lambda r: f"/api/v1/clients/{encoded_name}/torrents" in r.url,
+            timeout=UI_TIMEOUTS['api_response']
+        ) as response_info:
+            torrents_page.switch_to_client_tab(second_name)
+
+        assert response_info.value.status == 200
 
 
 class TestTorrentsNavigation:

--- a/tests/ui/pages/torrents_page.py
+++ b/tests/ui/pages/torrents_page.py
@@ -7,6 +7,8 @@ The torrents page displays:
 - Torrent selection checkboxes and transfer button
 - Transfer modal for manual transfers
 """
+from urllib.parse import quote
+
 from playwright.sync_api import Page, expect
 from .base_page import BasePage
 
@@ -27,6 +29,8 @@ class TorrentsPage(BasePage):
     TORRENT_NAME = ".simple-torrent-name"
     TORRENT_STATE = ".simple-torrent-state"
     EMPTY_MESSAGE = ".empty-message"
+    CLIENT_ERROR_MESSAGE = ".client-error-message"
+    NO_CLIENTS_MESSAGE = ".no-clients-message"
     
     # Selection selectors
     TORRENT_CHECKBOX = ".torrent-checkbox"
@@ -155,22 +159,37 @@ class TorrentsPage(BasePage):
             f"{self.CLIENT_TAB_CONTENT}.active {self.EMPTY_MESSAGE}"
         ).is_visible()
     
-    def wait_for_api_refresh(self, timeout: int = 5000) -> None:
+    def wait_for_api_refresh(self, client_name: str | None = None, timeout: int = 15000) -> None:
         """Wait for next API poll.
         
-        Torrents page polls /api/v1/all_torrents every 3 seconds.
+        Torrents page polls /api/v1/clients/<client>/torrents every 10 seconds.
         
         Args:
+            client_name: Expected client name. Defaults to the active tab.
             timeout: Maximum time to wait in milliseconds
             
         Raises:
             playwright.sync_api.TimeoutError: If no API response within timeout
         """
-        with self.page.expect_response(
-            lambda r: "/api/v1/all_torrents" in r.url,
-            timeout=timeout
-        ):
+        active_client = client_name or self.get_active_client_tab()
+        if active_client:
+            encoded_name = quote(active_client, safe='')
+            matcher = lambda r: f"/api/v1/clients/{encoded_name}/torrents" in r.url
+        else:
+            matcher = lambda r: "/api/v1/clients/" in r.url and r.url.endswith("/torrents")
+
+        with self.page.expect_response(matcher, timeout=timeout):
             pass  # Wait for next poll cycle
+
+    def has_client_error_message(self) -> bool:
+        """Check if a client-level error message is visible in the active tab."""
+        return self.page.locator(
+            f"{self.CLIENT_TAB_CONTENT}.active {self.CLIENT_ERROR_MESSAGE}"
+        ).is_visible()
+
+    def has_no_clients_message(self) -> bool:
+        """Check if the page shows the no-clients-configured state."""
+        return self.page.locator(self.NO_CLIENTS_MESSAGE).is_visible()
 
     # ===================================================================
     # Selection helpers

--- a/tests/unit/test_transfer_torrent_filtering.py
+++ b/tests/unit/test_transfer_torrent_filtering.py
@@ -6,8 +6,12 @@ Tests that transfer torrents are correctly filtered from:
 """
 from unittest.mock import Mock, MagicMock, patch
 
+from flask import Blueprint, Flask
+
 from transferarr.models.torrent import Torrent, TorrentState
 from transferarr.services.media_managers import RadarrManager, SonarrManager
+from transferarr.web.routes.api.torrents import register_routes as register_torrent_routes
+from transferarr.web.services import NotFoundError, ServiceUnavailableError
 from transferarr.web.services.torrent_service import TorrentService
 
 
@@ -437,3 +441,142 @@ class TestAllClientTorrentsFiltering:
         result = service.get_all_client_torrents()
         
         assert result["source-deluge"] == {}
+
+
+class TestClientTorrents:
+    """Tests for TorrentService.get_client_torrents()."""
+
+    def _make_service(self, torrents, clients):
+        manager = Mock()
+        manager.torrents = torrents
+        manager.download_clients = clients
+        return TorrentService(manager)
+
+    def _make_client(self, torrents_dict=None):
+        client = Mock()
+        client.is_connected.return_value = True
+        client.get_all_torrents_status.return_value = torrents_dict or {}
+        return client
+
+    def test_returns_requested_client_only(self):
+        tracked = _make_tracked_torrent(transfer_hash=TRANSFER_HASH)
+        client = self._make_client({
+            TRANSFER_HASH: {"name": "Transfer", "state": "Downloading"},
+            "cc" * 20: {"name": "Movie", "state": "Seeding"},
+        })
+        other_client = self._make_client({"dd" * 20: {"name": "Other", "state": "Seeding"}})
+
+        service = self._make_service(
+            [tracked],
+            {"source-deluge": client, "target-deluge": other_client},
+        )
+
+        result = service.get_client_torrents("source-deluge")
+
+        assert TRANSFER_HASH not in result
+        assert "cc" * 20 in result
+        other_client.get_all_torrents_status.assert_not_called()
+
+    def test_missing_client_raises_not_found(self):
+        service = self._make_service([], {})
+
+        with patch.object(service, "_get_transfer_hashes", return_value=set()):
+            try:
+                service.get_client_torrents("missing-client")
+                assert False, "Expected NotFoundError"
+            except NotFoundError as exc:
+                assert exc.resource_type == "Client"
+                assert exc.identifier == "missing-client"
+
+    def test_disconnected_client_raises_service_unavailable(self):
+        client = Mock()
+        client.is_connected.return_value = False
+        service = self._make_service([], {"source-deluge": client})
+
+        with patch.object(service, "_get_transfer_hashes", return_value=set()):
+            try:
+                service.get_client_torrents("source-deluge")
+                assert False, "Expected ServiceUnavailableError"
+            except ServiceUnavailableError as exc:
+                assert exc.details["reason"] == "not_connected"
+                assert exc.details["client"] == "source-deluge"
+
+    def test_unsupported_client_raises_service_unavailable(self):
+        client = Mock(spec=[])
+        service = self._make_service([], {"source-deluge": client})
+
+        with patch.object(service, "_get_transfer_hashes", return_value=set()):
+            try:
+                service.get_client_torrents("source-deluge")
+                assert False, "Expected ServiceUnavailableError"
+            except ServiceUnavailableError as exc:
+                assert exc.details["reason"] == "listing_not_supported"
+
+    def test_fetch_failure_raises_service_unavailable(self):
+        client = Mock()
+        client.is_connected.return_value = True
+        client.get_all_torrents_status.side_effect = RuntimeError("boom")
+        service = self._make_service([], {"source-deluge": client})
+
+        with patch.object(service, "_get_transfer_hashes", return_value=set()):
+            try:
+                service.get_client_torrents("source-deluge")
+                assert False, "Expected ServiceUnavailableError"
+            except ServiceUnavailableError as exc:
+                assert exc.details["reason"] == "fetch_failed"
+
+
+class TestClientTorrentsRoute:
+    """Tests for the per-client torrents API route."""
+
+    def _make_app(self, manager):
+        app = Flask(__name__)
+        app.config["TORRENT_MANAGER"] = manager
+        bp = Blueprint("test_torrents_api", __name__, url_prefix="/api/v1")
+        register_torrent_routes(bp)
+        app.register_blueprint(bp)
+        return app
+
+    def _make_manager(self, torrents=None, clients=None):
+        manager = Mock()
+        manager.torrents = torrents or []
+        manager.download_clients = clients or {}
+        return manager
+
+    def test_route_returns_filtered_client_torrents(self):
+        tracked = _make_tracked_torrent(transfer_hash=TRANSFER_HASH)
+        client = Mock()
+        client.is_connected.return_value = True
+        client.get_all_torrents_status.return_value = {
+            TRANSFER_HASH: {"name": "Transfer", "state": "Downloading"},
+            "cc" * 20: {"name": "Movie", "state": "Seeding"},
+        }
+        app = self._make_app(self._make_manager([tracked], {"source-deluge": client}))
+
+        response = app.test_client().get("/api/v1/clients/source-deluge/torrents")
+
+        assert response.status_code == 200
+        payload = response.get_json()["data"]
+        assert TRANSFER_HASH not in payload
+        assert "cc" * 20 in payload
+
+    def test_route_returns_404_for_missing_client(self):
+        app = self._make_app(self._make_manager())
+
+        response = app.test_client().get("/api/v1/clients/missing-client/torrents")
+
+        assert response.status_code == 404
+        error = response.get_json()["error"]
+        assert error["code"] == "CLIENT_NOT_FOUND"
+
+    def test_route_returns_503_for_disconnected_client(self):
+        client = Mock()
+        client.is_connected.return_value = False
+        app = self._make_app(self._make_manager(clients={"source-deluge": client}))
+
+        response = app.test_client().get("/api/v1/clients/source-deluge/torrents")
+
+        assert response.status_code == 503
+        error = response.get_json()["error"]
+        assert error["code"] == "SERVICE_UNAVAILABLE"
+        assert error["details"]["reason"] == "not_connected"

--- a/transferarr/web/routes/api/torrents.py
+++ b/transferarr/web/routes/api/torrents.py
@@ -2,8 +2,8 @@
 Torrent routes for listing and status information.
 """
 from flask import current_app
-from transferarr.web.services import TorrentService
-from .responses import success_response, server_error_response, error_response
+from transferarr.web.services import NotFoundError, ServiceUnavailableError, TorrentService
+from .responses import not_found_response, success_response, server_error_response, error_response
 import logging
 
 logger = logging.getLogger("transferarr")
@@ -86,15 +86,21 @@ def register_routes(bp):
             logger.error(f"Error getting torrents: {e}")
             return server_error_response(str(e))
 
-    @bp.route("/all_torrents")
-    def get_all_torrents():
-        """Get all torrents from all connected download clients.
+    @bp.route("/clients/<client_name>/torrents")
+    def get_client_torrents(client_name):
+        """Get torrents from a specific download client.
         ---
         tags:
           - Torrents
+        parameters:
+          - in: path
+            name: client_name
+            type: string
+            required: true
+            description: Name of the configured download client
         responses:
           200:
-            description: Dictionary of torrents by client
+            description: Torrents from the requested client keyed by torrent hash
             schema:
               type: object
               properties:
@@ -102,15 +108,28 @@ def register_routes(bp):
                   type: object
                   additionalProperties:
                     type: object
-                    description: Torrents from this client (keyed by torrent hash)
+                    description: Torrent status keyed by torrent hash
+          404:
+            description: Client not found
+          503:
+            description: Client unavailable
           500:
             description: Server error
         """
         try:
             service = TorrentService(current_app.config['TORRENT_MANAGER'])
-            return success_response(service.get_all_client_torrents())
+            return success_response(service.get_client_torrents(client_name))
+        except NotFoundError as e:
+            return not_found_response(e.resource_type, e.identifier)
+        except ServiceUnavailableError as e:
+            return error_response(
+                "SERVICE_UNAVAILABLE",
+                str(e),
+                getattr(e, "details", None),
+                status_code=503,
+            )
         except Exception as e:
-            logger.error(f"Error getting all torrents: {e}")
+            logger.error(f"Error getting torrents for client {client_name}: {e}")
             return server_error_response(str(e))
 
     @bp.route("/torrents/<torrent_hash>/retry", methods=["POST"])

--- a/transferarr/web/services/__init__.py
+++ b/transferarr/web/services/__init__.py
@@ -36,6 +36,14 @@ class ConfigSaveError(ServiceError):
     pass
 
 
+class ServiceUnavailableError(ServiceError):
+    """A required service or client is unavailable"""
+
+    def __init__(self, message: str, details: dict = None):
+        self.details = details or {}
+        super().__init__(message)
+
+
 from .download_client_service import DownloadClientService
 from .connection_service import ConnectionService
 from .torrent_service import TorrentService
@@ -47,6 +55,7 @@ __all__ = [
     'ConflictError',
     'ValidationError',
     'ConfigSaveError',
+    'ServiceUnavailableError',
     'DownloadClientService',
     'ConnectionService',
     'TorrentService',

--- a/transferarr/web/services/torrent_service.py
+++ b/transferarr/web/services/torrent_service.py
@@ -3,6 +3,8 @@ Service for torrent listing (read-only operations).
 """
 import logging
 
+from . import NotFoundError, ServiceUnavailableError
+
 logger = logging.getLogger("transferarr")
 
 
@@ -30,6 +32,51 @@ class TorrentService:
                     hashes.add(transfer_hash.lower())
         return hashes
 
+    def _filter_transfer_torrents(self, client_torrents: dict) -> dict:
+        """Filter internal transfer torrents from a client listing."""
+        transfer_hashes = self._get_transfer_hashes()
+        if not transfer_hashes:
+            return client_torrents
+        return {
+            h: info for h, info in client_torrents.items()
+            if h.lower() not in transfer_hashes
+        }
+
+    def get_client_torrents(self, client_name: str) -> dict:
+        """Get torrents for a single download client.
+
+        Raises:
+            NotFoundError: The named client does not exist.
+            ServiceUnavailableError: The client is disconnected, does not
+                support torrent listing, or failed while fetching torrents.
+        """
+        client = self.torrent_manager.download_clients.get(client_name)
+        if client is None:
+            raise NotFoundError("Client", client_name)
+
+        if not hasattr(client, 'is_connected') or not hasattr(client, 'get_all_torrents_status'):
+            raise ServiceUnavailableError(
+                f"Client '{client_name}' does not support torrent listing",
+                {"client": client_name, "reason": "listing_not_supported"},
+            )
+
+        if not client.is_connected():
+            raise ServiceUnavailableError(
+                f"Client '{client_name}' is not connected",
+                {"client": client_name, "reason": "not_connected"},
+            )
+
+        try:
+            client_torrents = client.get_all_torrents_status() or {}
+        except Exception as exc:
+            logger.error(f"Failed to get torrents from client {client_name}: {exc}")
+            raise ServiceUnavailableError(
+                f"Failed to fetch torrents from client '{client_name}'",
+                {"client": client_name, "reason": "fetch_failed"},
+            ) from exc
+
+        return self._filter_transfer_torrents(client_torrents)
+
     def get_all_client_torrents(self) -> dict:
         """Get all torrents from all download clients.
         
@@ -39,7 +86,6 @@ class TorrentService:
         Returns:
             Dict mapping client name to torrent dict
         """
-        transfer_hashes = self._get_transfer_hashes()
         all_torrents = {}
         
         for client_name, client in self.torrent_manager.download_clients.items():
@@ -52,13 +98,7 @@ class TorrentService:
                         continue
                     
                     client_torrents = client.get_all_torrents_status() or {}
-                    # Filter out transfer torrents
-                    if transfer_hashes:
-                        client_torrents = {
-                            h: info for h, info in client_torrents.items()
-                            if h.lower() not in transfer_hashes
-                        }
-                    all_torrents[client_name] = client_torrents
+                    all_torrents[client_name] = self._filter_transfer_torrents(client_torrents)
                 else:
                     logger.warning(f"Client {client_name} does not support torrent listing")
                     all_torrents[client_name] = {}

--- a/transferarr/web/static/css/pages/torrents.css
+++ b/transferarr/web/static/css/pages/torrents.css
@@ -540,10 +540,29 @@
 }
 
 /* Empty message styles */
-.empty-message {
+.client-status-message {
     padding: 20px;
     text-align: center;
+    border-radius: 8px;
+    margin: 12px 0;
+}
+
+.empty-message {
     color: #666;
+    background: #f6f7f8;
+    border: 1px solid #e2e5e9;
+}
+
+.client-error-message {
+    color: #7a1f1f;
+    background: #fff0f0;
+    border: 1px solid #f0c7c7;
+}
+
+.no-clients-message {
+    color: #555;
+    background: #f7f7f7;
+    border: 1px dashed #ccc;
 }
 
 /* Loading indicator styles */

--- a/transferarr/web/static/js/api.js
+++ b/transferarr/web/static/js/api.js
@@ -1,6 +1,26 @@
 /**
  * API client for Transferarr
  */
+async function fetchJson(url, options = {}) {
+    const response = await fetch(url, options);
+    let json = {};
+    try {
+        json = await response.json();
+    } catch {
+        json = {};
+    }
+
+    if (!response.ok) {
+        const error = new Error(json.error?.message || `Request failed with status ${response.status}`);
+        error.status = response.status;
+        error.code = json.error?.code || 'REQUEST_FAILED';
+        error.details = json.error?.details || {};
+        throw error;
+    }
+
+    return json.data || json;
+}
+
 const API = {
     /**
      * Fetch torrents data
@@ -8,30 +28,33 @@ const API = {
      */
     fetchTorrents: async function() {
         try {
-            const response = await fetch('/api/v1/torrents');
-            const json = await response.json();
-            // Unwrap data envelope (supports both old and new format)
-            return json.data || json;
+            return await fetchJson('/api/v1/torrents');
         } catch (error) {
             console.error('Error fetching torrents:', error);
             return [];
         }
     },
-    
+
     /**
-     * Fetch all torrents from all clients
-     * @returns {Promise<Object>} All torrents data by client
+     * Fetch configured download client names.
+     * @returns {Promise<Array<string>>} Configured client names
      */
-    fetchAllTorrents: async function() {
-        try {
-            const response = await fetch('/api/v1/all_torrents');
-            const json = await response.json();
-            // Unwrap data envelope (supports both old and new format)
-            return json.data || json;
-        } catch (error) {
-            console.error('Error fetching all torrents:', error);
-            return {};
-        }
+    fetchDownloadClients: async function() {
+        const clients = await fetchJson('/api/v1/download_clients');
+        return Object.keys(clients || {});
+    },
+
+    /**
+     * Fetch torrents for a single client.
+     * @param {string} clientName - Configured download client name
+     * @param {AbortSignal} [signal] - Abort signal for in-flight cancellation
+     * @returns {Promise<Object>} Torrent data keyed by torrent hash
+     */
+    fetchClientTorrents: async function(clientName, signal) {
+        return fetchJson(
+            `/api/v1/clients/${encodeURIComponent(clientName)}/torrents`,
+            { signal }
+        );
     },
 
     /**

--- a/transferarr/web/static/js/pages/torrents.js
+++ b/transferarr/web/static/js/pages/torrents.js
@@ -1,21 +1,27 @@
 // ============================================================================
 // State
 // ============================================================================
-/** @type {Object<string, Object>} Cached all-torrents data, keyed by client name */
+/** @type {Object<string, Object>} Cached torrent data, keyed by client name */
 let allTorrentsCache = {};
 /** @type {Set<string>} Selected torrent hashes (lowercase) */
 const selectedHashes = new Set();
 /** @type {string|null} Client name whose torrents are currently selected */
 let selectionSourceClient = null;
+/** @type {Array<string>} Configured client names */
+let clientNames = [];
+/** @type {string|null} Currently active client tab */
+let activeClientName = null;
+/** @type {number|null} Poll timer ID */
+let pollTimerId = null;
+/** @type {AbortController|null} Abort controller for the active client fetch */
+let activeFetchController = null;
+/** @type {number} Poll interval for active-client refreshes */
+const POLL_INTERVAL_MS = 10000;
 
 // ============================================================================
 // Bootstrap & Polling
 // ============================================================================
 document.addEventListener('DOMContentLoaded', function() {
-    showLoadingIndicator();
-    fetchAllTorrents();
-    setInterval(fetchAllTorrents, 3000);
-
     // Transfer button
     document.getElementById('transfer-selected-btn')
         .addEventListener('click', openTransferModal);
@@ -39,7 +45,30 @@ document.addEventListener('DOMContentLoaded', function() {
         .addEventListener('click', function(e) {
             if (e.target === this) closeTransferModal();
         });
+
+    void initializeTorrentsPage();
 });
+
+async function initializeTorrentsPage() {
+    showLoadingIndicator();
+
+    try {
+        clientNames = await API.fetchDownloadClients();
+        initializeClientTabs(clientNames);
+
+        if (clientNames.length === 0) {
+            renderNoClientsConfigured();
+            return;
+        }
+
+        await switchToClient(clientNames[0]);
+    } catch (error) {
+        if (error.name === 'AbortError') return;
+        renderNoClientsConfigured('Unable to load download clients');
+    } finally {
+        hideLoadingIndicator();
+    }
+}
 
 function showLoadingIndicator() {
     const el = document.getElementById('loading-indicator');
@@ -51,15 +80,81 @@ function hideLoadingIndicator() {
     if (el) el.classList.add('hidden');
 }
 
-async function fetchAllTorrents() {
+function stopPolling() {
+    if (pollTimerId !== null) {
+        clearTimeout(pollTimerId);
+        pollTimerId = null;
+    }
+}
+
+function scheduleNextPoll(clientName = activeClientName) {
+    stopPolling();
+    if (!clientName || document.hidden) return;
+
+    pollTimerId = window.setTimeout(async () => {
+        pollTimerId = null;
+
+        if (activeClientName !== clientName || document.hidden) {
+            return;
+        }
+
+        await refreshClientTorrents(clientName);
+
+        if (activeClientName === clientName && !document.hidden) {
+            scheduleNextPoll(clientName);
+        }
+    }, POLL_INTERVAL_MS);
+}
+
+function startPolling() {
+    scheduleNextPoll(activeClientName);
+}
+
+function abortActiveFetch() {
+    if (activeFetchController) {
+        activeFetchController.abort();
+        activeFetchController = null;
+    }
+}
+
+async function switchToClient(clientName) {
+    if (!clientName) return;
+
+    stopPolling();
+    abortActiveFetch();
+    setActiveClientTab(clientName);
+    await refreshClientTorrents(clientName);
+
+    if (activeClientName === clientName) {
+        startPolling();
+    }
+}
+
+async function refreshClientTorrents(clientName = activeClientName) {
+    if (!clientName) return;
+
+    const controller = new AbortController();
+    activeFetchController = controller;
+
     try {
-        const data = await API.fetchAllTorrents();
-        allTorrentsCache = data;
-        updateClientTabsWithAllTorrents(data);
-        hideLoadingIndicator();
+        const data = await API.fetchClientTorrents(clientName, controller.signal);
+        if (activeClientName !== clientName) return;
+
+        allTorrentsCache[clientName] = data;
+        renderClientTorrents(clientName, data);
     } catch (error) {
-        console.error('Error fetching all torrents:', error);
-        hideLoadingIndicator();
+        if (error.name === 'AbortError') return;
+        if (activeClientName !== clientName) return;
+
+        delete allTorrentsCache[clientName];
+        if (selectionSourceClient === clientName) {
+            clearSelection();
+        }
+        renderClientError(clientName, error.message || `Unable to load torrents for ${clientName}`);
+    } finally {
+        if (activeFetchController === controller) {
+            activeFetchController = null;
+        }
     }
 }
 
@@ -573,156 +668,200 @@ async function confirmTransfer() {
 // ============================================================================
 // Torrent Card Rendering (with checkboxes & cross-seed indicators)
 // ============================================================================
-function updateClientTabsWithAllTorrents(allTorrentsData) {
-    const clientNames = Object.keys(allTorrentsData);
-    if (clientNames.length === 0) return;
+function getSafeClientName(clientName) {
+    return clientName.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+}
 
+function initializeClientTabs(names) {
     const clientTabsContainer = document.getElementById('client-tabs');
     const clientTabContentsContainer = document.getElementById('client-tab-contents');
+
+    clientTabsContainer.innerHTML = '';
+    clientTabContentsContainer.innerHTML = '';
+
+    if (names.length === 0) {
+        clientTabsContainer.style.display = 'none';
+        clientTabContentsContainer.style.display = 'block';
+        return;
+    }
 
     clientTabsContainer.style.display = 'flex';
     clientTabContentsContainer.style.display = 'block';
 
-    // Remember active tab
-    let activeTabName = '';
-    const currentActive = document.querySelector('.client-tab.active');
-    if (currentActive) activeTabName = currentActive.dataset.client;
-
-    // Rebuild tabs if count changed
-    if (clientTabsContainer.children.length !== clientNames.length) {
-        clientTabsContainer.innerHTML = '';
-        clientTabContentsContainer.innerHTML = '';
-
-        clientNames.forEach((clientName, index) => {
-            const tab = document.createElement('div');
-            tab.className = 'client-tab';
-            if ((activeTabName && clientName === activeTabName) ||
-                (!activeTabName && index === 0)) {
-                tab.classList.add('active');
-            }
-            tab.textContent = clientName;
-            tab.dataset.client = clientName;
-            clientTabsContainer.appendChild(tab);
-
-            const tabContent = document.createElement('div');
-            tabContent.className = 'client-tab-content';
-            if ((activeTabName && clientName === activeTabName) ||
-                (!activeTabName && index === 0)) {
-                tabContent.classList.add('active');
-            }
-            tabContent.id = `client-${clientName.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '')}`;
-            clientTabContentsContainer.appendChild(tabContent);
+    names.forEach(clientName => {
+        const tab = document.createElement('div');
+        tab.className = 'client-tab';
+        tab.textContent = clientName;
+        tab.dataset.client = clientName;
+        tab.addEventListener('click', function() {
+            if (clientName === activeClientName) return;
+            void switchToClient(clientName);
         });
+        clientTabsContainer.appendChild(tab);
 
-        // Tab click handler
-        document.querySelectorAll('.client-tab').forEach(tab => {
-            tab.addEventListener('click', function() {
-                document.querySelectorAll('.client-tab').forEach(t => t.classList.remove('active'));
-                document.querySelectorAll('.client-tab-content').forEach(c => c.classList.remove('active'));
-                this.classList.add('active');
-                const cn = this.dataset.client;
-                const safeName = cn.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
-                const el = document.getElementById(`client-${safeName}`);
-                if (el) el.classList.add('active');
-            });
-        });
-    }
+        const tabContent = document.createElement('div');
+        tabContent.className = 'client-tab-content';
+        tabContent.id = `client-${getSafeClientName(clientName)}`;
+        clientTabContentsContainer.appendChild(tabContent);
+    });
+}
 
-    // Build cross-seed lookup for indicator rendering
-    const crossSeedGroups = {};
-    for (const clientName of clientNames) {
-        const groups = buildCrossSeedPathGroups(allTorrentsData[clientName] || {});
-        crossSeedGroups[clientName] = {};
-        for (const hashes of Object.values(groups)) {
-            for (const h of hashes) {
-                crossSeedGroups[clientName][h.toLowerCase()] = true;
-            }
-        }
-    }
+function setActiveClientTab(clientName) {
+    activeClientName = clientName;
 
-    // Update each client tab
-    clientNames.forEach(clientName => {
-        const clientTorrents = allTorrentsData[clientName] || {};
-        const safeName = clientName.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
-        const tabContent = document.getElementById(`client-${safeName}`);
-        if (!tabContent) return;
-
-        // Remove empty message
-        const existingMsg = tabContent.querySelector('.empty-message');
-        if (existingMsg) tabContent.removeChild(existingMsg);
-
-        let container = tabContent.querySelector('.client-torrent-container');
-        if (!container) {
-            container = document.createElement('div');
-            container.className = 'client-torrent-container';
-            tabContent.appendChild(container);
-        }
-
-        const existingCards = {};
-        Array.from(container.children).forEach(card => {
-            if (card.dataset.id) existingCards[card.dataset.id] = card;
-        });
-
-        const torrentIds = Object.keys(clientTorrents);
-
-        if (torrentIds.length === 0) {
-            container.innerHTML = '';
-            const emptyMsg = document.createElement('div');
-            emptyMsg.className = 'empty-message';
-            emptyMsg.textContent = `No torrents for ${clientName}`;
-            emptyMsg.style.padding = '20px';
-            emptyMsg.style.textAlign = 'center';
-            emptyMsg.style.color = '#666';
-            tabContent.appendChild(emptyMsg);
-            return;
-        }
-
-        torrentIds.forEach(torrentId => {
-            const torrentData = clientTorrents[torrentId];
-            const isCrossSeed = !!crossSeedGroups[clientName]?.[torrentId.toLowerCase()];
-            const isSeeding = (torrentData.state || '').toLowerCase() === 'seeding';
-
-            if (existingCards[torrentId]) {
-                updateClientTorrentCard(existingCards[torrentId], torrentData, isCrossSeed, isSeeding, torrentId, clientName);
-                delete existingCards[torrentId];
-            } else {
-                container.appendChild(createClientTorrentCard(torrentId, torrentData, isCrossSeed, isSeeding, clientName));
-            }
-        });
-
-        // Remove stale cards
-        Object.values(existingCards).forEach(card => container.removeChild(card));
+    document.querySelectorAll('.client-tab').forEach(tab => {
+        tab.classList.toggle('active', tab.dataset.client === clientName);
     });
 
-    // Prune selected hashes that no longer exist on the source client
-    if (selectionSourceClient && selectedHashes.size > 0) {
-        const clientTorrents = allTorrentsData[selectionSourceClient] || {};
-        const lowerIds = new Set(Object.keys(clientTorrents).map(h => h.toLowerCase()));
-        let pruned = false;
-        for (const hash of [...selectedHashes]) {
-            if (!lowerIds.has(hash)) {
-                selectedHashes.delete(hash);
-                pruned = true;
-            }
-        }
-        if (pruned) {
-            if (selectedHashes.size === 0) selectionSourceClient = null;
-            updateSelectionUI();
+    document.querySelectorAll('.client-tab-content').forEach(content => {
+        content.classList.toggle('active', content.id === `client-${getSafeClientName(clientName)}`);
+    });
+}
+
+function getClientTabContent(clientName) {
+    return document.getElementById(`client-${getSafeClientName(clientName)}`);
+}
+
+function ensureClientTorrentContainer(tabContent) {
+    let container = tabContent.querySelector('.client-torrent-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'client-torrent-container';
+        tabContent.appendChild(container);
+    }
+    return container;
+}
+
+function clearClientStatusMessages(tabContent) {
+    tabContent.querySelectorAll('.client-status-message').forEach(message => message.remove());
+}
+
+function renderNoClientsConfigured(message = 'No download clients configured') {
+    const clientTabsContainer = document.getElementById('client-tabs');
+    const clientTabContentsContainer = document.getElementById('client-tab-contents');
+
+    clientTabsContainer.innerHTML = '';
+    clientTabsContainer.style.display = 'none';
+    clientTabContentsContainer.style.display = 'block';
+    clientTabContentsContainer.innerHTML = '';
+
+    const status = document.createElement('div');
+    status.className = 'client-status-message no-clients-message';
+    status.textContent = message;
+    clientTabContentsContainer.appendChild(status);
+}
+
+function renderClientStatusMessage(clientName, message, kind = 'empty') {
+    const tabContent = getClientTabContent(clientName);
+    if (!tabContent) return;
+
+    const container = ensureClientTorrentContainer(tabContent);
+    container.innerHTML = '';
+    clearClientStatusMessages(tabContent);
+
+    const status = document.createElement('div');
+    status.className = `client-status-message ${kind === 'error' ? 'client-error-message' : 'empty-message'}`;
+    status.textContent = message;
+    tabContent.appendChild(status);
+}
+
+function renderClientError(clientName, message) {
+    renderClientStatusMessage(clientName, message, 'error');
+}
+
+function pruneSelectedHashes(clientName, clientTorrents) {
+    if (selectionSourceClient !== clientName || selectedHashes.size === 0) return;
+
+    const lowerIds = new Set(Object.keys(clientTorrents).map(hash => hash.toLowerCase()));
+    let pruned = false;
+
+    for (const hash of [...selectedHashes]) {
+        if (!lowerIds.has(hash)) {
+            selectedHashes.delete(hash);
+            pruned = true;
         }
     }
 
-    // Ensure active tab
-    if (!document.querySelector('.client-tab.active') && clientNames.length > 0) {
-        const firstTab = document.querySelector('.client-tab');
-        if (firstTab) {
-            firstTab.classList.add('active');
-            const cn = firstTab.dataset.client;
-            const safeName = cn.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
-            const el = document.getElementById(`client-${safeName}`);
-            if (el) el.classList.add('active');
-        }
+    if (pruned) {
+        if (selectedHashes.size === 0) selectionSourceClient = null;
+        updateSelectionUI();
     }
 }
+
+function renderClientTorrents(clientName, clientTorrents) {
+    const tabContent = getClientTabContent(clientName);
+    if (!tabContent) return;
+
+    const container = ensureClientTorrentContainer(tabContent);
+    clearClientStatusMessages(tabContent);
+
+    const groups = buildCrossSeedPathGroups(clientTorrents || {});
+    const crossSeedHashes = {};
+    for (const hashes of Object.values(groups)) {
+        for (const hash of hashes) {
+            crossSeedHashes[hash.toLowerCase()] = true;
+        }
+    }
+
+    const existingCards = {};
+    Array.from(container.children).forEach(card => {
+        if (card.dataset.id) existingCards[card.dataset.id] = card;
+    });
+
+    const torrentIds = Object.keys(clientTorrents);
+    if (torrentIds.length === 0) {
+        renderClientStatusMessage(clientName, `No torrents for ${clientName}`);
+        pruneSelectedHashes(clientName, clientTorrents);
+        return;
+    }
+
+    torrentIds.forEach(torrentId => {
+        const torrentData = clientTorrents[torrentId];
+        const isCrossSeed = !!crossSeedHashes[torrentId.toLowerCase()];
+        const isSeeding = (torrentData.state || '').toLowerCase() === 'seeding';
+
+        if (existingCards[torrentId]) {
+            updateClientTorrentCard(existingCards[torrentId], torrentData, isCrossSeed, isSeeding, torrentId, clientName);
+            delete existingCards[torrentId];
+        } else {
+            container.appendChild(createClientTorrentCard(torrentId, torrentData, isCrossSeed, isSeeding, clientName));
+        }
+    });
+
+    Object.values(existingCards).forEach(card => container.removeChild(card));
+    pruneSelectedHashes(clientName, clientTorrents);
+}
+
+function clearClientViews() {
+    stopPolling();
+    abortActiveFetch();
+    allTorrentsCache = {};
+    clientNames = [];
+    activeClientName = null;
+    clearSelection();
+}
+
+window.addEventListener('beforeunload', function() {
+    stopPolling();
+    abortActiveFetch();
+    clearClientViews();
+});
+
+window.addEventListener('pagehide', function() {
+    stopPolling();
+    abortActiveFetch();
+    clearClientViews();
+});
+
+window.addEventListener('visibilitychange', function() {
+    if (document.hidden) {
+        stopPolling();
+        return;
+    }
+    if (activeClientName) {
+        startPolling();
+    }
+});
 
 /**
  * Create the inline transfer button for a seeding torrent card.


### PR DESCRIPTION
Closes #24

## Summary
- replace the bulk `/api/v1/all_torrents` UI path with a per-client torrents endpoint and explicit 404/503 handling
- refactor the Torrents page to fetch configured clients separately and poll only the active tab
- switch polling to a non-overlapping one-shot scheduler with a 10-second default interval, and update tests/docs for the new behavior

## Validation
- ./run_tests.sh tests/integration/api/ -v
- ./run_tests.sh tests/ui/e2e/test_e2e_workflows.py -v