### PR TITLE
Add manual-only connection mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ All configuration is JSON-based (`config.json`). Structure:
 {
   "media_managers": [{"type": "radarr|sonarr", "host", "port", "api_key"}],
   "download_clients": {"name": {"type": "deluge", "connection_type": "rpc|web", ...}},
-  "connections": {"name": {"from": "client_name", "to": "client_name", "transfer_config": {...}}},
+  "connections": {"name": {"from": "client_name", "to": "client_name", "manual_only": false, "transfer_config": {...}}},
   "history": {"enabled": true, "retention_days": 90, "track_progress": true},
   "auth": {"enabled": true, "username": "admin", "password_hash": "$2b$...", "session_timeout_minutes": 60},
   "api": {"key": "tr_...", "key_required": true}

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -42,6 +42,7 @@ Transferarr uses a JSON configuration file. Create `config.json` with the follow
     "homelab-to-seedbox": {
       "from": "homelab-deluge",
       "to": "seedbox-deluge",
+      "manual_only": false,
       "transfer_config": {
         "from": {
           "type": "local"
@@ -131,6 +132,7 @@ Connections are defined as an object where each key is a unique connection name:
 | *(key)* | string | Unique connection name (e.g., `"homelab-to-seedbox"`) |
 | `from` | string | Name of source download client |
 | `to` | string | Name of destination download client |
+| `manual_only` | boolean | If `true`, the connection is available for manual transfers only and skipped by automatic media manager routing. Defaults to `false`. |
 | `transfer_config` | object | Transfer method configuration (see [Transfer Config](#transfer-config)) |
 
 Additional path fields depend on the transfer method — see the Transfer Config section below.

--- a/tests/integration/api/test_connection_api.py
+++ b/tests/integration/api/test_connection_api.py
@@ -55,6 +55,7 @@ class TestFileTransferConnectionApi:
         assert data['data']['name'] == 'test-file-conn'
         assert data['data']['from'] == 'source-deluge'
         assert data['data']['to'] == 'target-deluge'
+        assert data['data']['manual_only'] is False
         assert data['warnings'] == []
 
         # Cleanup
@@ -114,6 +115,7 @@ class TestTorrentConnectionApi:
         assert data['data']['name'] == 'test-torrent-conn'
         assert data['data']['from'] == 'source-deluge'
         assert data['data']['to'] == 'target-deluge'
+        assert data['data']['manual_only'] is False
         assert data['warnings'] == []
 
         # Cleanup
@@ -169,6 +171,7 @@ class TestTorrentConnectionApi:
         )
         assert update_resp.status_code == 200, f"Expected 200, got {update_resp.status_code}: {update_resp.text}"
         assert update_resp.json()['warnings'] == []
+        assert update_resp.json()['data']['manual_only'] is False
 
         # Verify the update via list
         list_resp = requests.get(base_url, timeout=TIMEOUTS['api_response'])
@@ -179,6 +182,47 @@ class TestTorrentConnectionApi:
 
         # Cleanup
         requests.delete(f"{base_url}/update-test-conn", timeout=TIMEOUTS['api_response'])
+
+    def test_update_preserves_manual_only_when_omitted(self):
+        """PUT without manual_only keeps the existing routing mode."""
+        base_url = f"{get_api_url()}/connections"
+
+        create_payload = {
+            "name": "preserve-manual-only",
+            "from": "source-deluge",
+            "to": "target-deluge",
+            "manual_only": True,
+            "transfer_config": {
+                "type": "torrent",
+                "destination_path": "/downloads",
+            },
+        }
+        create_resp = requests.post(base_url, json=create_payload, timeout=TIMEOUTS['api_response'])
+        assert create_resp.status_code == 201, f"Expected 201, got {create_resp.status_code}: {create_resp.text}"
+
+        update_payload = {
+            "from": "source-deluge",
+            "to": "target-deluge",
+            "transfer_config": {
+                "type": "torrent",
+                "destination_path": "/new-downloads",
+            },
+        }
+        update_resp = requests.put(
+            f"{base_url}/preserve-manual-only",
+            json=update_payload,
+            timeout=TIMEOUTS['api_response'],
+        )
+        assert update_resp.status_code == 200, f"Expected 200, got {update_resp.status_code}: {update_resp.text}"
+        assert update_resp.json()['data']['manual_only'] is True
+
+        list_resp = requests.get(base_url, timeout=TIMEOUTS['api_response'])
+        connections = list_resp.json()['data']
+        updated = [c for c in connections if c['name'] == 'preserve-manual-only']
+        assert len(updated) == 1
+        assert updated[0]['manual_only'] is True
+
+        requests.delete(f"{base_url}/preserve-manual-only", timeout=TIMEOUTS['api_response'])
 
     def test_test_torrent_connection_checks_tracker(self):
         """POST test with torrent config verifies clients + tracker."""
@@ -229,6 +273,7 @@ class TestConnectionWarningApi:
 
         data = response.json()
         assert data['data']['name'] == 'chain-warning-create'
+        assert data['data']['manual_only'] is False
         assert data['warnings'] == [
             "Connection target-deluge -> target-deluge-2 creates a chain (source-deluge -> target-deluge -> target-deluge-2). "
             "Transferarr does not support multi-hop transfers. Torrents on source-deluge will transfer to target-deluge "

--- a/tests/ui/fast/test_navigation.py
+++ b/tests/ui/fast/test_navigation.py
@@ -112,14 +112,14 @@ class TestDirectURLAccess:
     
     def test_history_direct_access(self, page: Page, base_url: str):
         """Test that history page is accessible via direct URL."""
-        page.goto(f"{base_url}/history")
+        page.goto(f"{base_url}/history", wait_until="domcontentloaded")
         
         expect(page).to_have_title("Transferarr - History")
         expect(page.locator("h2")).to_contain_text("Transfer History")
     
     def test_settings_direct_access(self, page: Page, base_url: str):
         """Test that settings page is accessible via direct URL."""
-        page.goto(f"{base_url}/settings")
+        page.goto(f"{base_url}/settings", wait_until="domcontentloaded")
         
         expect(page).to_have_title("Transferarr - Settings")
         expect(page.locator("h2")).to_contain_text("Settings")

--- a/tests/ui/fast/test_torrents.py
+++ b/tests/ui/fast/test_torrents.py
@@ -694,6 +694,7 @@ class TestTorrentsPolling:
             "hashes": ["aaa111"],
             "source_client": "source-deluge",
             "destination_client": "target-deluge",
+            "connection_name": "source-to-target",
             "include_cross_seeds": False,
             "delete_source_cross_seeds": True,
         }

--- a/tests/unit/test_connection_service.py
+++ b/tests/unit/test_connection_service.py
@@ -1,9 +1,11 @@
-"""Unit tests for ConnectionService chain warnings."""
+"""Unit tests for ConnectionService chain warnings and connection guards."""
 
 from unittest.mock import Mock
 
 import pytest
 
+from transferarr.models.torrent import Torrent, TorrentState
+from transferarr.web.services import ConflictError
 from transferarr.web.services.connection_service import ConnectionService
 
 
@@ -28,11 +30,17 @@ def _make_client(name: str) -> Mock:
     return client
 
 
-def _make_runtime_connection(name: str, from_client: Mock, to_client: Mock) -> Mock:
+def _make_runtime_connection(name: str, from_client: Mock, to_client: Mock, manual_only: bool = False) -> Mock:
     connection = Mock()
     connection.name = name
     connection.from_client = from_client
     connection.to_client = to_client
+    connection.manual_only = manual_only
+    connection.transfer_config = {"type": "torrent"}
+    connection.is_torrent_transfer = True
+    connection.get_active_transfers_count.return_value = 0
+    connection.get_total_transfers_count.return_value = 0
+    connection.max_transfers = 3
     return connection
 
 
@@ -66,6 +74,7 @@ def _make_manager(existing_connections=None) -> Mock:
     manager.download_clients = download_clients
     manager.connections = runtime_connections
     manager.config = {"connections": config_connections}
+    manager.torrents = []
     manager.save_config.return_value = True
     return manager
 
@@ -78,6 +87,11 @@ def patch_transfer_connection(monkeypatch):
         connection.from_client = from_client_obj
         connection.to_client = to_client_obj
         connection.transfer_config = connection_config["transfer_config"]
+        connection.manual_only = connection_config.get("manual_only", False)
+        connection.is_torrent_transfer = connection.transfer_config.get("type") == "torrent"
+        connection.get_active_transfers_count.return_value = 0
+        connection.get_total_transfers_count.return_value = 0
+        connection.max_transfers = 3
         return connection
 
     monkeypatch.setattr(
@@ -102,6 +116,7 @@ class TestConnectionServiceWarnings:
             "name": "isolated",
             "from": "client-a",
             "to": "client-b",
+            "manual_only": False,
         }
 
     def test_add_connection_warns_for_inbound_chain(self):
@@ -298,3 +313,80 @@ class TestConnectionServiceWarnings:
                 "client-c",
             )
         ]
+
+
+class TestConnectionServiceManualOnly:
+    def test_add_connection_persists_manual_only(self):
+        manager = _make_manager()
+        service = ConnectionService(manager)
+
+        result = service.add_connection({
+            "name": "manual-only",
+            "from": "client-a",
+            "to": "client-b",
+            "manual_only": True,
+            "transfer_config": {"type": "torrent"},
+        })
+
+        assert manager.config["connections"]["manual-only"]["manual_only"] is True
+        assert manager.connections["manual-only"].manual_only is True
+        assert result["connection"]["manual_only"] is True
+
+    def test_list_connections_includes_manual_only(self):
+        manager = _make_manager([("a-to-b", "client-a", "client-b")])
+        manager.connections["a-to-b"].manual_only = True
+        service = ConnectionService(manager)
+
+        result = service.list_connections()
+
+        assert result[0]["manual_only"] is True
+
+    def test_update_connection_rejects_in_use_connection(self):
+        manager = _make_manager([("a-to-b", "client-a", "client-b")])
+        torrent = Torrent(name="Tracked", id="abc123", connection_name="a-to-b")
+        torrent.state = TorrentState.HOME_SEEDING
+        manager.torrents = [torrent]
+        service = ConnectionService(manager)
+
+        with pytest.raises(ConflictError, match="currently in use"):
+            service.update_connection("a-to-b", {
+                "from": "client-a",
+                "to": "client-b",
+                "manual_only": False,
+                "transfer_config": {"type": "torrent"},
+            })
+
+    def test_update_connection_preserves_manual_only_when_omitted(self):
+        manager = _make_manager([("a-to-b", "client-a", "client-b")])
+        manager.config["connections"]["a-to-b"]["manual_only"] = True
+        manager.connections["a-to-b"].manual_only = True
+        service = ConnectionService(manager)
+
+        result = service.update_connection("a-to-b", {
+            "from": "client-a",
+            "to": "client-b",
+            "transfer_config": {"type": "torrent"},
+        })
+
+        assert manager.config["connections"]["a-to-b"]["manual_only"] is True
+        assert manager.connections["a-to-b"].manual_only is True
+        assert result["connection"]["manual_only"] is True
+
+    def test_delete_connection_rejects_in_use_connection(self):
+        manager = _make_manager([("a-to-b", "client-a", "client-b")])
+        torrent = Torrent(name="Tracked", id="abc123", connection_name="a-to-b")
+        torrent.state = TorrentState.HOME_SEEDING
+        manager.torrents = [torrent]
+        service = ConnectionService(manager)
+
+        with pytest.raises(ConflictError, match="currently in use"):
+            service.delete_connection("a-to-b")
+
+    def test_transfer_failed_does_not_block_connection_delete(self):
+        manager = _make_manager([("a-to-b", "client-a", "client-b")])
+        torrent = Torrent(name="Tracked", id="abc123", connection_name="a-to-b")
+        torrent.state = TorrentState.TRANSFER_FAILED
+        manager.torrents = [torrent]
+        service = ConnectionService(manager)
+
+        assert service.delete_connection("a-to-b") == "a-to-b"

--- a/tests/unit/test_manual_transfer.py
+++ b/tests/unit/test_manual_transfer.py
@@ -123,8 +123,8 @@ class TestGetDestinations:
         result = service.get_destinations("source-deluge")
         assert result == []
 
-    def test_deduplicates_destinations(self):
-        """Multiple connections to the same target should only list it once."""
+    def test_returns_each_connection_for_duplicate_target(self):
+        """Multiple connections to the same target should each be listed."""
         manager = _make_mock_manager()
         # Add a second connection to same target
         conn2 = Mock()
@@ -136,9 +136,8 @@ class TestGetDestinations:
 
         service = ManualTransferService(manager)
         result = service.get_destinations("source-deluge")
-        # Should deduplicate by client name — first connection wins
-        assert len(result) == 1
-        assert result[0]["client"] == "target-deluge"
+        assert len(result) == 2
+        assert [dest["connection"] for dest in result] == ["source-to-target", "source-to-target-2"]
 
 
 # ──────────────────────────────────────────────────
@@ -340,6 +339,40 @@ class TestValidateAndInitiate:
                 "source_client": "source-deluge",
                 "destination_client": "target-deluge",
             })
+
+    def test_raises_for_ambiguous_connection_without_connection_name(self):
+        service, manager = self._make_service_with_data(torrents_data=_make_torrents_data(["abc123"]))
+        conn2 = Mock()
+        conn2.from_client = manager.download_clients["source-deluge"]
+        conn2.to_client = manager.download_clients["target-deluge"]
+        conn2.name = "source-to-target-2"
+        conn2.is_torrent_transfer = False
+        manager.connections["source-to-target-2"] = conn2
+
+        with pytest.raises(ValidationError, match="Multiple connections"):
+            service.validate_and_initiate({
+                "hashes": ["abc123"],
+                "source_client": "source-deluge",
+                "destination_client": "target-deluge",
+            })
+
+    def test_uses_explicit_connection_name_when_multiple_match(self):
+        service, manager = self._make_service_with_data(torrents_data=_make_torrents_data(["abc123"]))
+        conn2 = Mock()
+        conn2.from_client = manager.download_clients["source-deluge"]
+        conn2.to_client = manager.download_clients["target-deluge"]
+        conn2.name = "source-to-target-2"
+        conn2.is_torrent_transfer = False
+        manager.connections["source-to-target-2"] = conn2
+
+        service.validate_and_initiate({
+            "hashes": ["abc123"],
+            "source_client": "source-deluge",
+            "destination_client": "target-deluge",
+            "connection_name": "source-to-target-2",
+        })
+
+        assert manager.create_manual_transfers.call_args.kwargs["connection"] is conn2
 
     def test_raises_for_hash_not_on_client(self):
         service, _ = self._make_service_with_data(torrents_data={})

--- a/tests/unit/test_torrent_service.py
+++ b/tests/unit/test_torrent_service.py
@@ -32,6 +32,90 @@ def _make_torrent(name="Test.Movie.2024", state=TorrentState.TORRENT_DOWNLOADING
     return t
 
 
+class TestAutomaticConnectionSelection:
+    def test_skips_manual_only_connections(self):
+        source_client = Mock()
+        source_client.name = "source-deluge"
+
+        manual_only = Mock()
+        manual_only.from_client = source_client
+        manual_only.manual_only = True
+
+        automatic = Mock()
+        automatic.from_client = source_client
+        automatic.manual_only = False
+
+        manager = Mock(spec=TorrentManager)
+        manager.connections = {
+            "manual": manual_only,
+            "automatic": automatic,
+        }
+        manager._select_automatic_connection = TorrentManager._select_automatic_connection.__get__(manager)
+
+        assert manager._select_automatic_connection("source-deluge") is automatic
+
+
+class TestTorrentConnectionPersistence:
+    def test_connection_name_round_trips(self):
+        source = Mock()
+        source.name = "source-deluge"
+        target = Mock()
+        target.name = "target-deluge"
+
+        torrent = Torrent(
+            name="Test.Movie.2024",
+            id="abc123",
+            home_client=source,
+            home_client_name="source-deluge",
+            target_client=target,
+            target_client_name="target-deluge",
+            connection_name="source-to-target",
+        )
+
+        restored = Torrent.from_dict(
+            torrent.to_dict(),
+            {
+                "source-deluge": source,
+                "target-deluge": target,
+            },
+        )
+
+        assert restored.connection_name == "source-to-target"
+
+    def test_does_not_rebind_to_different_target_when_target_already_known(self):
+        source = Mock()
+        source.name = "source-deluge"
+        target = Mock()
+        target.name = "target-deluge"
+        other_target = Mock()
+        other_target.name = "other-target"
+
+        torrent = Torrent(
+            name="Test.Movie.2024",
+            id="abc123",
+            home_client=source,
+            home_client_name="source-deluge",
+            target_client=target,
+            target_client_name="target-deluge",
+        )
+
+        connection = Mock()
+        connection.from_client = source
+        connection.to_client = other_target
+        connection.manual_only = False
+        connection.name = "source-to-other"
+
+        manager = Mock(spec=TorrentManager)
+        manager.connections = {"source-to-other": connection}
+        manager._select_automatic_connection = TorrentManager._select_automatic_connection.__get__(manager)
+        manager._get_connection_for_torrent = TorrentManager._get_connection_for_torrent.__get__(manager)
+
+        assert manager._get_connection_for_torrent(torrent) is None
+        assert torrent.target_client is target
+        assert torrent.target_client_name == "target-deluge"
+        assert torrent.connection_name is None
+
+
 # ──────────────────────────────────────────────────
 # Test _reregister_pending_transfers
 # ──────────────────────────────────────────────────
@@ -716,6 +800,8 @@ class TestPrivateTorrentEarlyGate:
         manager.media_managers = []
         manager.download_clients = {connection.from_client.name: connection.from_client}
         manager.running = False  # single iteration
+        manager._select_automatic_connection = TorrentManager._select_automatic_connection.__get__(manager)
+        manager._get_connection_for_torrent = TorrentManager._get_connection_for_torrent.__get__(manager)
         manager.update_torrents = TorrentManager.update_torrents.__get__(manager)
         return manager
 
@@ -779,6 +865,16 @@ class TestPrivateTorrentEarlyGate:
 
         # Should not have entered the create queue
         assert torrent.state != TorrentState.TORRENT_CREATE_QUEUE
+
+    def test_missing_matching_connection_sets_error(self):
+        """A HOME_SEEDING torrent without a valid route should fail loudly."""
+        torrent = self._make_seeding_torrent()
+        conn = self._make_torrent_connection(to_name="other-target", source_type=None)
+
+        manager = self._make_manager_for_update(torrent, conn)
+        manager.update_torrents()
+
+        assert torrent.state == TorrentState.ERROR
 
     def test_non_private_torrent_magnet_only_proceeds(self):
         """Non-private torrent in magnet-only mode proceeds to TORRENT_CREATE_QUEUE."""

--- a/transferarr/models/torrent.py
+++ b/transferarr/models/torrent.py
@@ -39,7 +39,7 @@ class Torrent:
     def __init__(self, name=None, id=None, state=None, 
                  home_client=None, target_client=None,
                  home_client_info=None, home_client_name=None, target_client_info=None, 
-                 target_client_name=None, save_callback=None, media_manager=None,
+                 target_client_name=None, connection_name=None, save_callback=None, media_manager=None,
                  transfer=None, _transfer_id=None, delete_source_cross_seeds=None):
         self.name = name
         self.id = id
@@ -50,6 +50,7 @@ class Torrent:
         self.target_client = target_client
         self.target_client_name = target_client_name
         self.target_client_info = target_client_info
+        self.connection_name = connection_name
         self.save_callback = save_callback
         self.media_manager = media_manager
         self.size = 0
@@ -82,6 +83,12 @@ class Torrent:
     def set_target_client(self, client):
         self.target_client = client
         self.target_client_name = client.name
+
+    def bind_connection(self, connection):
+        if self.target_client is None or self.target_client_name != connection.to_client.name:
+            self.set_target_client(connection.to_client)
+        self.connection_name = connection.name
+        self.mark_dirty()
 
     def __str__(self):
         return f"{self.name} - {self.id}: - {self.state.name if self.state else None}"
@@ -126,6 +133,7 @@ class Torrent:
             "home_client_info": self.home_client_info,
             "target_client_info": self.target_client_info,
             "target_client_name": self.target_client_name,
+            "connection_name": self.connection_name,
             "progress": self._get_display_progress(),
             "size": self._get_display_size(),
             "transfer_speed": self._get_display_transfer_speed(),
@@ -232,6 +240,7 @@ class Torrent:
             target_client=download_clients.get(data.get("target_client_name")),
             target_client_info=data.get("target_client_info"),
             target_client_name=data.get("target_client_name"),
+            connection_name=data.get("connection_name"),
             save_callback=save_callback,
             media_manager=media_manager,
             transfer=data.get("transfer"),  # Restore transfer data if present

--- a/transferarr/services/torrent_service.py
+++ b/transferarr/services/torrent_service.py
@@ -514,6 +514,43 @@ class TorrentManager:
             logger.error(f"Failed to save configuration: {e}")
             return False
 
+    def _select_automatic_connection(self, source_client_name):
+        for connection in self.connections.values():
+            if connection.from_client.name == source_client_name and not connection.manual_only:
+                return connection
+        return None
+
+    def _get_connection_for_torrent(self, torrent):
+        if torrent.connection_name:
+            connection = self.connections.get(torrent.connection_name)
+            if connection:
+                return connection
+            logger.warning(
+                f"Bound connection '{torrent.connection_name}' not found for torrent {torrent.name}"
+            )
+            return None
+
+        if torrent.home_client and torrent.target_client:
+            for connection in self.connections.values():
+                if (connection.from_client.name == torrent.home_client.name and
+                        connection.to_client.name == torrent.target_client.name):
+                    torrent.bind_connection(connection)
+                    return connection
+
+            logger.warning(
+                f"No matching connection found from {torrent.home_client.name} "
+                f"to {torrent.target_client.name} for torrent {torrent.name}"
+            )
+            return None
+
+        if torrent.home_client:
+            connection = self._select_automatic_connection(torrent.home_client.name)
+            if connection:
+                torrent.bind_connection(connection)
+            return connection
+
+        return None
+
     def create_manual_transfers(self, hashes, source_client, dest_client,
                                 connection, delete_source_cross_seeds=True):
         """Create and initiate manual transfers for the given torrent hashes.
@@ -558,6 +595,7 @@ class TorrentManager:
                 torrent.set_home_client_info(info)
                 torrent.set_progress_from_home_client_info()
                 torrent.set_target_client(dest_client)
+                torrent.connection_name = connection.name
                 torrent.media_manager = None  # Manual transfer — no media manager
                 torrent.delete_source_cross_seeds = delete_source_cross_seeds
                 torrent.state = TorrentState.HOME_SEEDING  # no save_callback yet
@@ -736,13 +774,10 @@ class TorrentManager:
                     continue
                 else:
                     ### Time to find it's target using our connections
-                    for connection in self.connections.values():
-                        found_connection = False
-                        if connection.from_client.name == torrent.home_client.name:
-                            torrent.set_target_client(connection.to_client)
-                            found_connection = True
-                            break
-                    if not found_connection:
+                    connection = self._select_automatic_connection(torrent.home_client.name)
+                    if connection:
+                        torrent.bind_connection(connection)
+                    else:
                         logger.debug(f"Torrent {torrent.name}: client {torrent.home_client.name} has no connection to any other client, not tracking")
                         # torrents.remove(torrent)
                         torrents_to_remove.append(torrent)
@@ -768,45 +803,49 @@ class TorrentManager:
                 ### Now we check if it's seeding
                 if torrent.state == TorrentState.HOME_SEEDING:
                     logger.debug(f"Torrent {torrent.name} is seeding on home client: {torrent.home_client.name}, checking connection")
-                    for connection in self.connections.values():
-                        if connection.from_client.name == torrent.home_client.name and connection.to_client.name == torrent.target_client.name:
-                            if torrent.target_client.has_torrent(torrent):
-                                torrent.state = torrent.target_client.get_torrent_state(torrent)
-                                torrent.set_target_client_info(torrent.target_client.get_torrent_info(torrent))
-                                logger.debug(f"Torrent {torrent.name} already exists on {torrent.target_client.name}")
-                            else:
-                                logger.debug(f"Torrent {torrent.name} not found on {torrent.target_client.name}, ready to transfer")
-                                # Check if this is a torrent-based transfer
-                                if connection.is_torrent_transfer:
-                                    if self.torrent_transfer_handler:
-                                        # Early gate: reject private torrents in magnet-only mode
-                                        # before creating any transfer torrents.
-                                        if connection.source_type is None:
-                                            try:
-                                                is_private = torrent.home_client.is_private_torrent(torrent.id)
-                                            except Exception as e:
-                                                logger.warning(
-                                                    f"Could not check private flag for {torrent.name}: {e}. "
-                                                    f"Proceeding (will re-check in handle_seeding)."
-                                                )
-                                                is_private = False
-                                            if is_private:
-                                                logger.error(
-                                                    f"Torrent '{torrent.name}' is a private tracker torrent but "
-                                                    f"connection '{connection.name}' has no source access configured. "
-                                                    f"Configure source access (SFTP or local) to transfer private torrents."
-                                                )
-                                                torrent.state = TorrentState.TRANSFER_FAILED
-                                                break
-                                        torrent.state = TorrentState.TORRENT_CREATE_QUEUE
-                                    else:
-                                        logger.error(
-                                            f"Torrent {torrent.name} needs torrent transfer but tracker is disabled. "
-                                            f"Enable the tracker or change connection '{connection.name}' to a file-based transfer."
+                    connection = self._get_connection_for_torrent(torrent)
+                    if not connection:
+                        logger.warning(f"No connection found for torrent {torrent.name}")
+                        torrent.state = TorrentState.ERROR
+                        continue
+
+                    if torrent.target_client.has_torrent(torrent):
+                        torrent.state = torrent.target_client.get_torrent_state(torrent)
+                        torrent.set_target_client_info(torrent.target_client.get_torrent_info(torrent))
+                        logger.debug(f"Torrent {torrent.name} already exists on {torrent.target_client.name}")
+                    else:
+                        logger.debug(f"Torrent {torrent.name} not found on {torrent.target_client.name}, ready to transfer")
+                        # Check if this is a torrent-based transfer
+                        if connection.is_torrent_transfer:
+                            if self.torrent_transfer_handler:
+                                # Early gate: reject private torrents in magnet-only mode
+                                # before creating any transfer torrents.
+                                if connection.source_type is None:
+                                    try:
+                                        is_private = torrent.home_client.is_private_torrent(torrent.id)
+                                    except Exception as e:
+                                        logger.warning(
+                                            f"Could not check private flag for {torrent.name}: {e}. "
+                                            f"Proceeding (will re-check in handle_seeding)."
                                         )
-                                else:
-                                    # SFTP/local file transfer
-                                    connection.enqueue_copy_torrent(torrent)
+                                        is_private = False
+                                    if is_private:
+                                        logger.error(
+                                            f"Torrent '{torrent.name}' is a private tracker torrent but "
+                                            f"connection '{connection.name}' has no source access configured. "
+                                            f"Configure source access (SFTP or local) to transfer private torrents."
+                                        )
+                                        torrent.state = TorrentState.TRANSFER_FAILED
+                                        continue
+                                torrent.state = TorrentState.TORRENT_CREATE_QUEUE
+                            else:
+                                logger.error(
+                                    f"Torrent {torrent.name} needs torrent transfer but tracker is disabled. "
+                                    f"Enable the tracker or change connection '{connection.name}' to a file-based transfer."
+                                )
+                        else:
+                            # SFTP/local file transfer
+                            connection.enqueue_copy_torrent(torrent)
             ### If the torrent is in COPYING state, check if it's in the connection queue
             elif torrent.state == TorrentState.COPYING:
                 # Check if the torrent is in any connection's active transfers
@@ -818,16 +857,11 @@ class TorrentManager:
                 
                 # If not in the queue, find the appropriate connection and enqueue it
                 if not already_in_queue and torrent.home_client and torrent.target_client:
-                    connection_found = False
-                    for connection in self.connections.values():
-                        if (connection.from_client.name == torrent.home_client.name and 
-                            connection.to_client.name == torrent.target_client.name):
-                            logger.debug(f"Re-enqueueing torrent {torrent.name} for copying with connection from {connection.from_client.name} to {connection.to_client.name}")
-                            connection.enqueue_copy_torrent(torrent)
-                            connection_found = True
-                            break
-                    
-                    if not connection_found:
+                    connection = self._get_connection_for_torrent(torrent)
+                    if connection:
+                        logger.debug(f"Re-enqueueing torrent {torrent.name} for copying with connection from {connection.from_client.name} to {connection.to_client.name}")
+                        connection.enqueue_copy_torrent(torrent)
+                    else:
                         logger.warning(f"Could not find appropriate connection for torrent {torrent.name} from {torrent.home_client.name} to {torrent.target_client.name}")
             ### Handle torrent-based transfer states
             elif torrent.state in [TorrentState.TORRENT_CREATE_QUEUE, TorrentState.TORRENT_CREATING,
@@ -839,13 +873,7 @@ class TorrentManager:
                     continue
                 
                 # Find the connection for this torrent
-                connection = None
-                for conn in self.connections.values():
-                    if (conn.from_client.name == torrent.home_client.name and 
-                        conn.to_client.name == torrent.target_client.name):
-                        connection = conn
-                        break
-                
+                connection = self._get_connection_for_torrent(torrent)
                 if not connection:
                     logger.error(f"No connection found for torrent {torrent.name}")
                     torrent.state = TorrentState.ERROR

--- a/transferarr/services/transfer_connection.py
+++ b/transferarr/services/transfer_connection.py
@@ -124,6 +124,7 @@ class TransferConnection:
         self.name = name
         self.config = config
         self.transfer_config = config.get("transfer_config")
+        self.manual_only = config.get("manual_only", False)
         self.source_dot_torrent_path = config.get("source_dot_torrent_path")
         self.source_torrent_download_path = config.get("source_torrent_download_path")
         self.destination_dot_torrent_tmp_dir = config.get("destination_dot_torrent_tmp_dir")

--- a/transferarr/web/routes/api/auth.py
+++ b/transferarr/web/routes/api/auth.py
@@ -60,8 +60,6 @@ def register_routes(api_bp):
             schema:
               type: object
               properties:
-                success:
-                  type: boolean
                 data:
                   type: object
                   properties:
@@ -71,6 +69,9 @@ def register_routes(api_bp):
                       type: string
                     session_timeout_minutes:
                       type: integer
+                    runtime_session_timeout_minutes:
+                      type: integer
+                      description: Currently applied runtime timeout in minutes. Changes may require restart to take effect.
           401:
             description: Authentication required
         """
@@ -229,8 +230,6 @@ def register_routes(api_bp):
             schema:
               type: object
               properties:
-                success:
-                  type: boolean
                 data:
                   type: object
                   properties:
@@ -325,14 +324,15 @@ def register_routes(api_bp):
             schema:
               type: object
               properties:
-                success:
-                  type: boolean
                 data:
                   type: object
                   properties:
                     key:
                       type: string
                       description: The newly generated API key
+                    message:
+                      type: string
+                      description: Success message describing the key regeneration result
           401:
             description: Authentication required
         """

--- a/transferarr/web/routes/api/connections.py
+++ b/transferarr/web/routes/api/connections.py
@@ -60,6 +60,9 @@ def register_routes(bp):
                       to:
                         type: string
                         description: Destination client name
+                      manual_only:
+                        type: boolean
+                        description: Whether the connection is only used for manual transfers
                       transfer_type:
                         type: string
                         enum: [file, torrent]
@@ -123,6 +126,10 @@ def register_routes(bp):
                 to:
                   type: string
                   description: Destination download client name
+                manual_only:
+                  type: boolean
+                  default: false
+                  description: Whether the connection should only be used for manual transfers. Defaults to false when omitted on create.
                 transfer_config:
                   type: object
                   description: |
@@ -160,6 +167,8 @@ def register_routes(bp):
                       type: string
                     to:
                       type: string
+                    manual_only:
+                      type: boolean
                 message:
                   type: string
                 warnings:
@@ -297,6 +306,9 @@ def register_routes(bp):
                   type: string
                 to:
                   type: string
+                manual_only:
+                  type: boolean
+                  description: Whether the connection should only be used for manual transfers. If omitted on update, the existing value is preserved.
                 transfer_config:
                   type: object
                   description: |
@@ -330,6 +342,8 @@ def register_routes(bp):
                       type: string
                     to:
                       type: string
+                    manual_only:
+                      type: boolean
                 message:
                   type: string
                 warnings:
@@ -341,7 +355,7 @@ def register_routes(bp):
           404:
             description: Connection or client not found
           409:
-            description: New connection name already exists
+            description: New connection name already exists or the connection is currently in use
           500:
             description: Server error
         """
@@ -361,7 +375,8 @@ def register_routes(bp):
         except NotFoundError as e:
             return not_found_response(e.resource_type, e.identifier)
         except ConflictError as e:
-            return error_response("DUPLICATE_CONNECTION", str(e), status_code=409)
+          code = "DUPLICATE_CONNECTION" if "already exists" in str(e) else "CONNECTION_IN_USE"
+          return error_response(code, str(e), status_code=409)
         except ConfigSaveError as e:
             return server_error_response(str(e))
         except Exception as e:
@@ -385,6 +400,8 @@ def register_routes(bp):
             description: Connection deleted successfully
           404:
             description: Connection not found
+          409:
+            description: Connection is currently in use by an active or queued transfer
           500:
             description: Server error
         """
@@ -395,6 +412,8 @@ def register_routes(bp):
             return success_response(None, f"Connection '{connection_name}' deleted successfully")
         except NotFoundError as e:
             return not_found_response(e.resource_type, e.identifier)
+        except ConflictError as e:
+            return error_response("CONNECTION_IN_USE", str(e), status_code=409)
         except ConfigSaveError as e:
             return server_error_response(str(e))
         except Exception as e:

--- a/transferarr/web/routes/api/manual_transfers.py
+++ b/transferarr/web/routes/api/manual_transfers.py
@@ -101,6 +101,9 @@ def register_routes(bp):
                 destination_client:
                   type: string
                   description: Name of the destination download client
+                connection_name:
+                  type: string
+                  description: Exact connection name to use when multiple routes exist between the same clients
                 include_cross_seeds:
                   type: boolean
                   default: false

--- a/transferarr/web/schemas/__init__.py
+++ b/transferarr/web/schemas/__init__.py
@@ -203,6 +203,7 @@ class ConnectionSchema(Schema):
     from_ = fields.Str(required=True, data_key="from")
     to = fields.Str(required=True)
     transfer_config = fields.Dict(required=True)
+    manual_only = fields.Bool(load_default=False)
     # Path fields: required for file transfers, ignored for torrent transfers
     source_dot_torrent_path = fields.Str(load_default=None)
     source_torrent_download_path = fields.Str(load_default=None)
@@ -240,6 +241,7 @@ class ConnectionUpdateSchema(Schema):
     from_ = fields.Str(required=True, data_key="from")
     to = fields.Str(required=True)
     transfer_config = fields.Dict(required=True)
+    manual_only = fields.Bool(load_default=None)
     # Path fields: required for file transfers, ignored for torrent transfers
     source_dot_torrent_path = fields.Str(load_default=None)
     source_torrent_download_path = fields.Str(load_default=None)
@@ -286,7 +288,7 @@ class BrowseRequestSchema(Schema):
     """Schema for POST /api/v1/browse"""
     type = fields.Str(required=True, validate=validate.OneOf(["local", "sftp"]))
     path = fields.Str(load_default="/")
-    sftp = fields.Nested(SFTPConfigSchema, load_default=None)
+    config = fields.Nested(SFTPConfigSchema, load_default=None)
 
 
 # =============================================================================
@@ -305,5 +307,6 @@ class ManualTransferSchema(Schema):
     )
     source_client = fields.Str(required=True, validate=validate.Length(min=1))
     destination_client = fields.Str(required=True, validate=validate.Length(min=1))
+    connection_name = fields.Str(load_default=None)
     include_cross_seeds = fields.Bool(load_default=False)
     delete_source_cross_seeds = fields.Bool(load_default=True)

--- a/transferarr/web/services/connection_service.py
+++ b/transferarr/web/services/connection_service.py
@@ -1,7 +1,10 @@
 """
 Service for transfer connection CRUD operations.
 """
+from typing import Optional
+
 from transferarr.services.transfer_connection import TransferConnection, test_torrent_client_connectivity, _test_sftp_connectivity, _test_local_state_dir, is_torrent_transfer
+from transferarr.models.torrent import TorrentState
 from . import NotFoundError, ConflictError, ConfigSaveError
 import copy
 
@@ -110,6 +113,7 @@ class ConnectionService:
                 "name": name,
                 "from": connection.from_client.name,
                 "to": connection.to_client.name,
+                "manual_only": connection.manual_only,
                 "transfer_config": _mask_sftp_passwords(connection.transfer_config),
                 "transfer_type": transfer_type,
                 "active_transfers": connection.get_active_transfers_count(),
@@ -127,6 +131,43 @@ class ConnectionService:
             
             connections_data.append(conn_data)
         return connections_data
+
+    def _find_tracked_torrent_using_connection(self, connection_name: str, connection) -> Optional[object]:
+        torrents = getattr(self.torrent_manager, "torrents", None)
+        if torrents is None:
+            return None
+
+        try:
+            iterator = iter(torrents)
+        except TypeError:
+            return None
+
+        for torrent in iterator:
+            if torrent.state == TorrentState.TRANSFER_FAILED:
+                continue
+
+            if getattr(torrent, "connection_name", None) == connection_name:
+                return torrent
+
+            if getattr(torrent, "connection_name", None):
+                continue
+
+            if (getattr(torrent, "home_client_name", None) == connection.from_client.name
+                    and getattr(torrent, "target_client_name", None) == connection.to_client.name):
+                return torrent
+
+        return None
+
+    def _raise_if_connection_in_use(self, connection_name: str, connection) -> None:
+        torrent = self._find_tracked_torrent_using_connection(connection_name, connection)
+        if not torrent:
+            return
+
+        state_name = torrent.state.name if torrent.state else "unknown"
+        raise ConflictError(
+            f"Connection '{connection_name}' is currently in use by tracked torrent "
+            f"'{torrent.name}' (state: {state_name}). Finish or remove the transfer before changing or deleting this connection."
+        )
     
     def add_connection(self, data: dict) -> dict:
         """Add a new connection.
@@ -146,6 +187,7 @@ class ConnectionService:
         from_client = data["from"]
         to_client = data["to"]
         transfer_config = data["transfer_config"]
+        manual_only = data.get("manual_only", False)
         
         # Case-insensitive uniqueness check
         existing_names = {n.lower() for n in self.torrent_manager.connections.keys()}
@@ -163,6 +205,7 @@ class ConnectionService:
             "from": from_client,
             "to": to_client,
             "transfer_config": transfer_config,
+            "manual_only": manual_only,
         }
         
         # Include path fields only for file transfers
@@ -194,7 +237,12 @@ class ConnectionService:
         self.torrent_manager.connections[name] = new_connection
         
         return {
-            "connection": {"name": name, "from": from_client, "to": to_client},
+            "connection": {
+                "name": name,
+                "from": from_client,
+                "to": to_client,
+                "manual_only": manual_only,
+            },
             "warnings": warnings,
         }
     
@@ -216,10 +264,13 @@ class ConnectionService:
         actual_name, connection = _find_connection_by_name(self.torrent_manager.connections, name)
         if not connection:
             raise NotFoundError("Connection", name)
+
+        self._raise_if_connection_in_use(actual_name, connection)
         
         from_client = data["from"]
         to_client = data["to"]
         transfer_config = data["transfer_config"]
+        manual_only = data.get("manual_only")
         new_name = data.get("name")
         
         # Handle renaming
@@ -239,6 +290,12 @@ class ConnectionService:
         existing_connections = updated_config.get("connections")
         updated_connections = dict(existing_connections) if isinstance(existing_connections, dict) else {}
         existing_conn_config = updated_connections.get(actual_name, {})
+        existing_manual_only = existing_conn_config.get(
+            "manual_only",
+            getattr(connection, "manual_only", False),
+        )
+        if manual_only is None:
+            manual_only = existing_manual_only
         
         # Preserve SFTP passwords if masked/empty (handles both file from/to and torrent source.sftp)
         transfer_config = self._preserve_sftp_passwords(transfer_config, existing_conn_config)
@@ -248,6 +305,7 @@ class ConnectionService:
             "from": from_client,
             "to": to_client,
             "transfer_config": transfer_config,
+            "manual_only": manual_only,
         }
         
         # Include path fields only for file transfers
@@ -281,7 +339,12 @@ class ConnectionService:
         to_client_obj.add_connection(new_connection)
         
         return {
-            "connection": {"name": final_name, "from": from_client, "to": to_client},
+            "connection": {
+                "name": final_name,
+                "from": from_client,
+                "to": to_client,
+                "manual_only": manual_only,
+            },
             "warnings": warnings,
         }
     
@@ -298,6 +361,8 @@ class ConnectionService:
         actual_name, connection = _find_connection_by_name(self.torrent_manager.connections, name)
         if not connection:
             raise NotFoundError("Connection", name)
+
+        self._raise_if_connection_in_use(actual_name, connection)
         
         updated_config = dict(self.torrent_manager.config)
         del updated_config["connections"][actual_name]

--- a/transferarr/web/services/manual_transfer_service.py
+++ b/transferarr/web/services/manual_transfer_service.py
@@ -37,18 +37,22 @@ class ManualTransferService:
             raise NotFoundError("Client", source_client)
 
         destinations = []
-        seen = set()
         for connection in self.torrent_manager.connections.values():
             if connection.from_client.name == source_client:
-                dest_name = connection.to_client.name
-                if dest_name not in seen:
-                    seen.add(dest_name)
-                    destinations.append({
-                        "client": dest_name,
-                        "connection": connection.name,
-                        "transfer_type": "torrent" if connection.is_torrent_transfer else "file",
-                    })
+                destinations.append({
+                    "client": connection.to_client.name,
+                    "connection": connection.name,
+                    "transfer_type": "torrent" if connection.is_torrent_transfer else "file",
+                })
         return destinations
+
+    def _get_matching_connections(self, source_client_name: str, dest_client_name: str) -> list:
+        return [
+            connection
+            for connection in self.torrent_manager.connections.values()
+            if (connection.from_client.name == source_client_name
+                and connection.to_client.name == dest_client_name)
+        ]
 
     def detect_cross_seeds(self, client_name: str, torrents_data: dict) -> dict:
         """Detect cross-seed groups for torrents on a client.
@@ -100,6 +104,7 @@ class ManualTransferService:
         hashes = data.get("hashes", [])
         source_client_name = data["source_client"]
         dest_client_name = data["destination_client"]
+        connection_name = data.get("connection_name")
         include_cross_seeds = data.get("include_cross_seeds", False)
 
         # Validate we have hashes
@@ -119,18 +124,27 @@ class ManualTransferService:
         source_client = self.torrent_manager.download_clients[source_client_name]
         dest_client = self.torrent_manager.download_clients[dest_client_name]
 
-        # Find a connection from source to destination
-        connection = None
-        for conn in self.torrent_manager.connections.values():
-            if (conn.from_client.name == source_client_name
-                    and conn.to_client.name == dest_client_name):
-                connection = conn
-                break
+        matching_connections = self._get_matching_connections(source_client_name, dest_client_name)
 
-        if not connection:
-            raise ValidationError(
-                f"No connection configured from '{source_client_name}' to '{dest_client_name}'"
-            )
+        if connection_name:
+            connection = self.torrent_manager.connections.get(connection_name)
+            if not connection:
+                raise ValidationError(f"Connection '{connection_name}' not found")
+            if (connection.from_client.name != source_client_name
+                    or connection.to_client.name != dest_client_name):
+                raise ValidationError(
+                    f"Connection '{connection_name}' does not route from '{source_client_name}' to '{dest_client_name}'"
+                )
+        else:
+            if not matching_connections:
+                raise ValidationError(
+                    f"No connection configured from '{source_client_name}' to '{dest_client_name}'"
+                )
+            if len(matching_connections) > 1:
+                raise ValidationError(
+                    f"Multiple connections are configured from '{source_client_name}' to '{dest_client_name}'. Select an exact connection."
+                )
+            connection = matching_connections[0]
 
         # Validate tracker is available for torrent transfers
         if (connection.is_torrent_transfer

--- a/transferarr/web/static/js/modules/connections.js
+++ b/transferarr/web/static/js/modules/connections.js
@@ -154,6 +154,9 @@ function setConnectionEditMode(savedConnection) {
     document.getElementById('connectionName').value = savedConnection.name || '';
     document.getElementById('fromClient').value = savedConnection.from || '';
     document.getElementById('toClient').value = savedConnection.to || '';
+    if (Object.prototype.hasOwnProperty.call(savedConnection, 'manual_only')) {
+        document.getElementById('connectionManualOnly').checked = Boolean(savedConnection.manual_only);
+    }
     document.getElementById('connectionModalTitle').textContent = 'Edit Connection';
 }
 
@@ -342,11 +345,15 @@ function createConnectionCard(connection) {
     // Add connection details
     const transferType = connection.transfer_config?.type === 'torrent' ? 'Torrent' : 'File';
     const transferTypeClass = connection.transfer_config?.type === 'torrent' ? 'badge bg-info' : 'badge bg-secondary';
+    const routingMode = connection.manual_only
+        ? '<p><strong>Routing:</strong> <span class="badge bg-warning text-dark">Manual Only</span></p>'
+        : '';
     connectionInfo.innerHTML = `
         <p><strong>Status:</strong> <span class="status-badge ${connection.status.toLowerCase()}">${connection.status}</span></p>
         <p><strong>From Client:</strong> ${connection.from}</p>
         <p><strong>To Client:</strong> ${connection.to}</p>
         <p><strong>Transfer Type:</strong> <span class="${transferTypeClass}">${transferType}</span></p>
+        ${routingMode}
         <p><strong>Active Transfers:</strong> ${connection.active_transfers} / ${connection.max_transfers}</p>
         <p><strong>Total Transfers:</strong> ${connection.total_transfers}</p>
     `;
@@ -436,6 +443,7 @@ function editConnection(connection) {
     populateClientDropdowns().then(() => {
         // Populate the connection name field
         document.getElementById('connectionName').value = connection.name;
+        document.getElementById('connectionManualOnly').checked = Boolean(connection.manual_only);
         
         // Set selected client values after clients are loaded
         document.getElementById('fromClient').value = connection.from;
@@ -647,6 +655,7 @@ function resetConnectionForm() {
     document.getElementById('connectionForm').reset();
     document.getElementById('connectionId').value = '';
     document.getElementById('connectionName').value = '';
+    document.getElementById('connectionManualOnly').checked = false;
     clearConnectionWarnings();
     document.getElementById('saveConnectionBtn').disabled = true;
     resetTestConnectionBtn();
@@ -806,6 +815,7 @@ function testConnection() {
     const fromType = document.getElementById('fromType').value;
     const toType = document.getElementById('toType').value;
     const transferMethod = document.getElementById('transferMethod').value;
+    const manualOnly = document.getElementById('connectionManualOnly').checked;
     
     // Validate selection
     if (!fromClient || !toClient) {
@@ -1011,6 +1021,7 @@ function saveConnection() {
     const fromType = document.getElementById('fromType').value;
     const toType = document.getElementById('toType').value;
     const transferMethod = document.getElementById('transferMethod').value;
+    const manualOnly = document.getElementById('connectionManualOnly').checked;
     
     // Validate connection name
     if (!connectionName) {
@@ -1042,6 +1053,7 @@ function saveConnection() {
         name: connectionName,
         from: fromClient,
         to: toClient,
+        manual_only: manualOnly,
         transfer_config: {}
     };
     

--- a/transferarr/web/static/js/pages/torrents.js
+++ b/transferarr/web/static/js/pages/torrents.js
@@ -464,7 +464,7 @@ async function loadDestinations() {
         for (const dest of destinations) {
             const opt = document.createElement('option');
             opt.value = dest.client;
-            opt.textContent = `${dest.client} (${dest.transfer_type})`;
+            opt.textContent = `${dest.client} (${dest.transfer_type}, ${dest.connection})`;
             opt.dataset.connection = dest.connection;
             opt.dataset.transferType = dest.transfer_type;
             select.appendChild(opt);
@@ -743,10 +743,12 @@ async function confirmTransfer() {
 
     try {
         const deleteCrossSeeds = document.getElementById('deleteCrossSeeds')?.checked ?? true;
+        const selectedOption = destSelect.selectedOptions[0];
         const result = await API.initiateManualTransfer({
             hashes: [...selectedHashes],
             source_client: selectionSourceClient,
             destination_client: destSelect.value,
+            connection_name: selectedOption?.dataset.connection || null,
             include_cross_seeds: includeCrossSeeds,
             delete_source_cross_seeds: deleteCrossSeeds,
         });

--- a/transferarr/web/templates/partials/modals/connection_modal.html
+++ b/transferarr/web/templates/partials/modals/connection_modal.html
@@ -33,6 +33,16 @@
                         </select>
                         <small class="form-text text-muted">How files are transferred between clients</small>
                     </div>
+
+                    <div class="form-group mb-3">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="connectionManualOnly">
+                            <label class="form-check-label" for="connectionManualOnly">
+                                Only use for manual transfers
+                            </label>
+                        </div>
+                        <small class="form-text text-muted">Exclude this connection from automatic media manager routing.</small>
+                    </div>
                     
                     <div class="connection-layout-container">
                         <!-- Source (From) Client Section -->


### PR DESCRIPTION
Adds `manual_only` connections, keeps automatic routing off those routes, and makes manual transfers choose an exact connection.

Closes #23.